### PR TITLE
ci: every half is tested on every pull request

### DIFF
--- a/.github/workflows/ci-clients.yml
+++ b/.github/workflows/ci-clients.yml
@@ -1,0 +1,39 @@
+name: ci · clients
+
+# The CLI, the MCP server and the broker client each have a test project, and until 2026-09-05 none
+# of the three ran in CI — the server workflow builds the whole solution but runs only its own tests.
+# This job runs the other three. No path filter: a required check that a pull request can skip is a
+# check that protects nothing.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-clients-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build-test:
+    name: clients · build · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+      - name: Build
+        run: dotnet build dew_flow_creds_for_devs.slnx -c Release
+      # xUnit v3 on Microsoft Testing Platform: each test project is its own runner executable, and
+      # `dotnet test` has no VSTest host here — it would abort with a tooling error, not a test result.
+      - name: Test the CLI
+        run: ./src_cli/tests/bin/Release/net10.0/CredsCli.Tests
+      - name: Test the MCP server
+        run: ./src_mcp/tests/bin/Release/net10.0/CredsMcp.Tests
+      - name: Test the broker client
+        run: ./src_broker_client/tests/bin/Release/net10.0/BrokerClient.Tests

--- a/.github/workflows/ci-clients.yml
+++ b/.github/workflows/ci-clients.yml
@@ -23,7 +23,13 @@ jobs:
     name: clients · build · test
     runs-on: ubuntu-latest
     steps:
+      # This job builds and RUNS code from a pull request, so the checkout must not leave the
+      # token behind in the local git config where that code could reach it. `contents: read` bounds
+      # what the token can do; `persist-credentials: false` means the code never meets it at all.
+      # (CodeRabbit on this pull request; zizmor calls the pattern `artipacked`.)
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x

--- a/.github/workflows/ci-clients.yml
+++ b/.github/workflows/ci-clients.yml
@@ -27,13 +27,20 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-      - name: Build
-        run: dotnet build dew_flow_creds_for_devs.slnx -c Release
+      # The three test projects are built by name: the solution file does not carry all of them, and
+      # a project the solution never built is a runner executable that does not exist — which is how
+      # this job's first run failed on `No such file or directory`.
+      - name: Build the three test projects
+        run: |
+          dotnet build src_cli/tests/CredsCli.Tests.csproj -c Release
+          dotnet build src_mcp/tests/CredsMcp.Tests.csproj -c Release
+          dotnet build src_broker_client/tests/BrokerClient.Tests.csproj -c Release
       # xUnit v3 on Microsoft Testing Platform: each test project is its own runner executable, and
       # `dotnet test` has no VSTest host here — it would abort with a tooling error, not a test result.
+      # The executable is named by <AssemblyName>, which for the broker client is CredsBroker.Tests.
       - name: Test the CLI
         run: ./src_cli/tests/bin/Release/net10.0/CredsCli.Tests
       - name: Test the MCP server
         run: ./src_mcp/tests/bin/Release/net10.0/CredsMcp.Tests
       - name: Test the broker client
-        run: ./src_broker_client/tests/bin/Release/net10.0/BrokerClient.Tests
+        run: ./src_broker_client/tests/bin/Release/net10.0/CredsBroker.Tests

--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -13,9 +13,6 @@ on:
       - '.github/workflows/ci-extension.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'src_vs_code/**'
-      - '.github/workflows/ci-extension.yml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci-server.yml
+++ b/.github/workflows/ci-server.yml
@@ -23,19 +23,6 @@ on:
       - '.github/workflows/ci-server.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'src_minimalapi_server/**'
-      - 'deploy/**'
-      # The contract suite and the post-deploy checklist are part of this pipeline's verdict,
-      # so a change to either has to re-run it.
-      - 'http/**'
-      - 'POST_DEPLOY.md'
-      - 'Directory.Build.props'
-      - 'Directory.Packages.props'
-      - 'global.json'
-      - 'nuget.config'
-      - 'dew_flow_creds_for_devs.slnx'
-      - '.github/workflows/ci-server.yml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Three of this repository's five halves have test projects that never ran in CI: the CLI, the MCP
server and the broker client. The server workflow builds the whole solution and runs only
CredVaultServer.Tests; the extension workflow runs npm test. ci-clients.yml runs the other three, as
the runner executables xUnit v3 / MTP builds (dotnet test would abort here, not fail).

And the path filters are gone from the pull_request triggers of ci-server.yml and ci-extension.yml.
A required status check that a pull request can skip protects nothing: with the filters, a PR that
touched neither src_vs_code nor src_minimalapi_server never reported those checks, so they could not
be required without blocking such PRs forever. Every PR now runs every job, and every job becomes a
required check on main. The push triggers keep their filters; nothing is merged without a PR.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added continuous integration coverage for CLI, MCP server, and broker client test projects.

- **Chores**
  - Extension and server checks now run for every pull request targeting `main`, regardless of which files changed.
  - Added concurrency controls to cancel superseded workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->