### PR TITLE
ci: dependabot version updates, a pull request template, and semantic titles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot version updates — grouped, weekly, Monday morning Kyiv time, one pull request per
+# ecosystem. Security updates are separate and immediate (repository settings, 2026-09-05).
+#
+# Family exception: FluentAssertions stays on 7.x — 8.x changed its licence.
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      nuget-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      - dependency-name: "FluentAssertions"
+        update-types: ["version-update:semver-major"]
+    labels: ["dependencies", "nuget"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "npm"
+    directory: "/src_vs_code"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      npm-minor-and-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    labels: ["dependencies", "npm"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "docker"
+    directory: "/deploy"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    labels: ["dependencies", "docker"]
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "07:00"
+      timezone: "Europe/Kyiv"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels: ["dependencies", "ci"]
+    commit-message:
+      prefix: "ci(deps)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!-- The title is the changelog line: `type: what changed` — feat, fix, docs, test, chore, refactor, perf, ci, build. -->
+
+## What changed, and why
+
+<!-- The symptom or the ask first, then what shipped. This repository is public: nothing here may weaken the trust boundary — the server never holds a key that opens a vault. -->
+
+## Evidence
+
+- [ ] **Red-green:** every bug or problem spot here has a test that failed before the fix and passes after — name it.
+- [ ] **All the tests ran** — server, extension, cli, mcp, broker — and this is what they printed:
+
+```
+<paste the runners' summary lines>
+```
+
+## Documentation
+
+- [ ] `research/module_*.md`, README, CHANGELOG and the manifest (`package.json` / `.csproj`) updated where what they describe changed.
+- [ ] If this finishes a plan in `todo/`, it is promoted to `research/` here.
+- [ ] If a route changed: the `.http` contract suite has a request for it, and `POST_DEPLOY.md` still holds.
+
+## The reviewer
+
+<!-- Filled in about five minutes after opening: what CodeRabbit said, what was fixed, and what was NOT acted on — with the reason. -->
+
+## Release / deploy
+
+- [ ] No release needed / a tag will be cut on `main` after the merge: `<tag>`.
+- [ ] If the deploy auto-triggers: verified against the environment and its logs read.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+name: pr · title
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic:
+    name: pr · semantic title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            test
+            chore
+            refactor
+            perf
+            ci
+            build
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" starts with a capital letter; the family writes `type: lower-case what changed`.


### PR DESCRIPTION
The family's hardening list of 2026-09-05, epic 3: grouped weekly Dependabot updates for NuGet, the
extension's npm, the deploy images and the actions (FluentAssertions pinned below 8.x — its licence
changed); a template that asks for the red-green test, what all five runners printed, the docs, the
contract suite and the deploy verification; and the semantic-title check that keeps main's history
in the family's shape.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)