### PR TITLE
ci: toolchain majors are a decision, not an update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,16 @@ updates:
       npm-minor-and-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    # The toolchain is chosen by hand with the VS Code engine version: a major bump of TypeScript or
+    # of @types/node is a decision, not an update — the first two the bot proposed (5.9 -> 7.0,
+    # 20 -> 26) both failed typecheck on arrival, 2026-09-05.
+    ignore:
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/vscode"
+        update-types: ["version-update:semver-major"]
     labels: ["dependencies", "npm"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
TypeScript 5.9 -> 7.0 and @types/node 20 -> 26 arrived as Dependabot PRs and both failed typecheck;
the extension's toolchain is chosen by hand with the VS Code engine version. Majors of typescript,
@types/node and @types/vscode are ignored; minors and patches keep coming grouped.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)