### PR TITLE
fix: the image is built only from a push to main; a test regex meant a literal dot

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,9 +29,16 @@ jobs:
     name: build · smoke · publish
     runs-on: ubuntu-latest
     # A failed or cancelled server pipeline produces no image.
+    # Only a PUSH to main builds and publishes. `ci · server` also runs for pull requests, and a
+    # workflow_run chained to it would otherwise check out a pull request's head — from a fork,
+    # potentially — with packages:write in hand and build it into a published image (CodeQL
+    # actions/untrusted-checkout, 2026-09-05). A pull request is tested by its own workflows;
+    # nothing it contains is published until it is merged and pushed.
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.workflow_run.conclusion == 'success'
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
     permissions:
       contents: read
       packages: write

--- a/src_vs_code/src/test/sshBridge.test.ts
+++ b/src_vs_code/src/test/sshBridge.test.ts
@@ -281,7 +281,7 @@ test('the sanitiser is shared with the path builder, so the two cannot drift', (
   const path = remoteSocketPath(user, 'abc');
   const glob = sweepCommand(user);
 
-  assert.match(path, new RegExp(`/tmp/creds-${safeUserComponent(user)}-abc\.sock$`));
+  assert.match(path, new RegExp(`/tmp/creds-${safeUserComponent(user)}-abc[.]sock$`));
   assert.ok(glob.includes(`/tmp/creds-${safeUserComponent(user)}-*.sock`));
 });
 


### PR DESCRIPTION
CodeQL, 2026-09-05. actions/untrusted-checkout (high): docker.yml is chained to "ci · server" by
workflow_run, and that workflow also runs for pull requests — so a pull request's head, from a fork
potentially, could be checked out with packages:write in hand and built into a published image. The
job now runs only for a successful workflow_run of a PUSH to main (and by hand). A pull request is
tested by its own workflows; nothing it contains is published until merged.

js/useless-regexp-character-escape: inside a template literal `\.` is just `.`, so the test's
regex matched any character before `sock`. `[.]` is the dot it meant.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)