### PR TITLE
fix(agent): an internal failure tells the agent THAT, and the journal HOW

### DIFF
--- a/src_vs_code/src/brokerProtocol.ts
+++ b/src_vs_code/src/brokerProtocol.ts
@@ -62,6 +62,22 @@ export function errorBody(code: ErrorCode, message: string): ErrorBody {
   return { error: { code, message } };
 }
 
+/**
+ * What an agent is told when something under an action fails.
+ *
+ * <p>Fixed text, deliberately. The error it replaces was the caught exception's own message, which
+ * named a path, a driver frame or a query fragment on every occasion it fired — and an agent is a
+ * party that gets the RESULT and never the machinery. (CodeQL js/stack-trace-exposure, medium; it
+ * was right about the shape even though the reader here is a local process.)</p>
+ *
+ * <p>The diagnosis is not lost, it moves: the agent journal is local, it is what a person reads when
+ * an agent reports a failure, and it carries the reason beside what was asked for.</p>
+ *
+ * <p>Here rather than in the server, because this module is where the wire's vocabulary lives —
+ * beside `ErrorCode` and `errorBody`, which decide the rest of what a caller is told.</p>
+ */
+export const INTERNAL_FAILURE = 'The action failed inside this window. See the agent journal for the reason.';
+
 export interface HealthBody {
   ok: true;
   service: typeof SERVICE_NAME;

--- a/src_vs_code/src/brokerResponse.ts
+++ b/src_vs_code/src/brokerResponse.ts
@@ -36,6 +36,31 @@ export async function maskedBody(
 }
 
 /**
+ * The reason an action failed, as the JOURNAL may hold it.
+ *
+ * <p>A reviewer's finding, and the best of its round: moving the caught error out of the response
+ * and into the journal put it somewhere it had never been. A driver's message is exactly the place a
+ * credential turns up — `authentication failed for token sk-live-…`, a connection string with its
+ * password in it — and the journal is a local file that gets read, copied and backed up. So the same
+ * masker that strips secrets out of command output strips them out of this, and for the same
+ * reason.</p>
+ *
+ * <p><b>Not capped here</b>, and a reviewer asked for that too — checked and rejected: `formatAuditLine`
+ * already flattens and truncates the detail to 200 characters through `oneLine`, so a second cap at
+ * any larger number could never fire and a second cap at a smaller one would silently shorten every
+ * other detail this journal carries. What truncation does NOT do is redact, which is why the masking
+ * above is the part that had to be added.</p>
+ */
+export async function maskedReason(
+  entriesFor: ((accountId: string, entityId: string) => Promise<readonly MaskEntry[]>) | undefined,
+  where: { accountId: string; entityId: string },
+  reason: string,
+): Promise<string> {
+  const masked = (await maskedBody(entriesFor, where, { reason })) as { body: { reason?: unknown } };
+  return typeof masked.body.reason === 'string' ? masked.body.reason : reason;
+}
+
+/**
  * Destroy a one-use entry now that it has been used — and say so.
  *
  * <p>Only a successful call spends it. A refused, failed or not-supported call left the

--- a/src_vs_code/src/credsAgentServer.ts
+++ b/src_vs_code/src/credsAgentServer.ts
@@ -34,7 +34,7 @@ import { removeEndpoint, writeEndpoint } from './cliEndpoint';
 import { AliasThrottle } from './aliasThrottle';
 import { startOnce } from './idempotentStart';
 import { MaskEntry } from './secretMasker';
-import { burnIfSpent, maskedBody } from './brokerResponse';
+import { burnIfSpent, maskedBody, maskedReason } from './brokerResponse';
 
 /**
  * The broker: a loopback HTTP surface through which an agent asks this window
@@ -586,8 +586,10 @@ export class CredsAgentServer implements vscode.Disposable {
       await burnIfSpent(this.burnAfterUse, grant, result.status, this.note);
     } catch (error) {
       // THAT it failed, never HOW — see INTERNAL_FAILURE. The reason is not lost, it MOVES to the
-      // journal, which is local and is where a person looks when an agent reports a failure.
-      const why = `${summary} · ${describeError(error)}`;
+      // journal, which is local and is where a person looks when an agent reports a failure — and
+      // through the SAME masker the response body goes through, because a driver's message is
+      // exactly where a credential turns up.
+      const why = `${summary} · ${await maskedReason(this.maskEntriesFor, grant, describeError(error))}`;
       this.respondError(res, 'internal', INTERNAL_FAILURE, grant, action, why, via);
     }
   }

--- a/src_vs_code/src/credsAgentServer.ts
+++ b/src_vs_code/src/credsAgentServer.ts
@@ -3,6 +3,7 @@ import * as http from 'node:http';
 import * as vscode from 'vscode';
 import {
   ErrorCode,
+  INTERNAL_FAILURE,
   MAX_CONCURRENT_EXECS,
   MAX_REQUEST_BODY_BYTES,
   errorBody,
@@ -529,7 +530,7 @@ export class CredsAgentServer implements vscode.Disposable {
    * point would be a way for consent, masking or the audit to apply to one caller and not the
    * other — and the one that gets forgotten is always the newer path.</p>
    */
-  // eslint-disable-next-line complexity, max-lines-per-function
+  // eslint-disable-next-line complexity
   private async perform(
     res: http.ServerResponse,
     grant: Grant,
@@ -584,14 +585,10 @@ export class CredsAgentServer implements vscode.Disposable {
       // storage failure while burning must not cost the agent the result it already earned.
       await burnIfSpent(this.burnAfterUse, grant, result.status, this.note);
     } catch (error) {
-      this.respondError(
-        res,
-        'internal',
-        describeError(error),
-        grant,
-        action,
-        summary,
-      );
+      // THAT it failed, never HOW — see INTERNAL_FAILURE. The reason is not lost, it MOVES to the
+      // journal, which is local and is where a person looks when an agent reports a failure.
+      const why = `${summary} · ${describeError(error)}`;
+      this.respondError(res, 'internal', INTERNAL_FAILURE, grant, action, why, via);
     }
   }
 

--- a/src_vs_code/src/test/brokerWorld.ts
+++ b/src_vs_code/src/test/brokerWorld.ts
@@ -300,5 +300,8 @@ const SECRET = 'sk-live-9f2c41ab';
 
 const code = (answer: Answer): string => (answer.body.error as { code: string } | undefined)?.code ?? '';
 
-export { world, call, share, code, SECRET };
+/** The sentence a refusal carries, beside the code — what the agent is actually told. */
+const message = (answer: Answer): string => (answer.body.error as { message: string } | undefined)?.message ?? '';
+
+export { world, call, share, code, message, SECRET };
 export type { World, Answer, Ran };

--- a/src_vs_code/src/test/brokerWorld.ts
+++ b/src_vs_code/src/test/brokerWorld.ts
@@ -39,7 +39,14 @@ interface World {
   created: string[];
   presence: number;
   /** Set by the run() stub to whatever the action should answer. */
-  result: { status: number; body: Record<string, unknown> };
+  /**
+   * What the wrapped action answers — or, when it is an `Error`, what it THROWS.
+   *
+   * <p>The harness could express every outcome an action reaches by returning, and none it reaches
+   * by failing, so the catch around `run` had no test at all. That is the branch that decides what
+   * an agent is told about an internal failure.</p>
+   */
+  result: { status: number; body: Record<string, unknown> } | Error;
 }
 
 function world(options: {
@@ -102,7 +109,7 @@ function world(options: {
     summarize: (body: Record<string, unknown>): string => String(body.command ?? ''),
     run: (ctx: { entityId: string }, body: Record<string, unknown>): Promise<unknown> => {
       w.ran.push({ action: name, entityId: ctx.entityId, body });
-      return Promise.resolve(w.result);
+      return w.result instanceof Error ? Promise.reject(w.result) : Promise.resolve(w.result);
     },
   });
   const registry = {

--- a/src_vs_code/src/test/credsAgentServer.test.ts
+++ b/src_vs_code/src/test/credsAgentServer.test.ts
@@ -558,3 +558,51 @@ test('…and the journal keeps the reason, because that is where a person looks'
     w.server.dispose();
   }
 });
+
+/**
+ * The journal is a local FILE, so the reason that moves into it is masked and capped.
+ *
+ * <p>A reviewer's finding on the round that reviewed the move, and the best of it: taking the
+ * caught error out of the response and putting it in the journal put it somewhere it had never
+ * been. A driver's message is exactly where a credential turns up — `authentication failed for
+ * token …`, a connection string with its password in it — and a journal is read, copied and backed
+ * up. The masker that strips secrets out of command output strips them out of this too.</p>
+ */
+test('a secret inside the error is MASKED before it reaches the journal', async () => {
+  const w = world({ secrets: [{ value: SECRET, label: 'PASSWORD' }] });
+  w.result = new Error(`authentication failed for ${SECRET} against prod`);
+  try {
+    const { port, secret } = await share(w);
+
+    await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
+
+    const journal = w.audit.join('\n');
+    assert.ok(!journal.includes(SECRET), journal);
+    assert.match(journal, /authentication failed/, 'the diagnosis survives the masking');
+  } finally {
+    w.server.dispose();
+  }
+});
+
+test('a runaway error message is bounded — by the formatter, which already did it', async () => {
+  // A reviewer asked for a cap on the reason before it is journalled. Checked, and rejected: this
+  // is already true one layer down, where `formatAuditLine` flattens and truncates every detail to
+  // 200 characters through `oneLine`. A second cap at a larger number could never fire, and at a
+  // smaller one it would silently shorten every other detail this journal carries.
+  //
+  // Asserted anyway, because the reason it needs no cap is a property of another module and this is
+  // the test that would notice if that property went away.
+  const w = world({});
+  w.result = new Error('x'.repeat(5000));
+  try {
+    const { port, secret } = await share(w);
+
+    await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
+
+    const line = w.audit.find((l) => l.includes('internal')) ?? '';
+    assert.ok(line.length < 400, `journal line was ${line.length} characters`);
+    assert.match(line, /…$/, 'and it ends in an ellipsis rather than looking complete');
+  } finally {
+    w.server.dispose();
+  }
+});

--- a/src_vs_code/src/test/credsAgentServer.test.ts
+++ b/src_vs_code/src/test/credsAgentServer.test.ts
@@ -21,7 +21,8 @@ import { SERVICE_NAME } from '../brokerProtocol';
  * burning cannot cost the agent a result it already earned.</p>
  */
 
-import { SECRET, call, code, share, world } from './brokerWorld';
+import { INTERNAL_FAILURE } from '../brokerProtocol';
+import { SECRET, call, code, message, share, world } from './brokerWorld';
 
 test('health is unauthenticated — it is what lets the CLI check the port before sending a token', async () => {
   const w = world({});
@@ -499,6 +500,11 @@ test('the listing is a GET only — a POST to it is not an action route', async 
  * carries the real reason where it used to carry only the summary.</p>
  */
 test('an internal failure gives the agent a fixed sentence, never the error’s own text', async () => {
+  // Asserted as an EQUALITY, not as the absence of three strings — two reviewers made the same
+  // point and they were right: a negative assertion passes on the unfixed code for any error whose
+  // message happens not to contain them, so `Error('query failed')` would have gone green while
+  // still handing its own text to the agent. What is promised is a CONSTANT, so that is what is
+  // checked, and then the realistic leak is checked on top of it.
   const w = world({});
   w.result = new Error('ENOENT: /home/dev/.ssh/id_ed25519_prod, open failed at Connection.parse:214');
   try {
@@ -507,10 +513,27 @@ test('an internal failure gives the agent a fixed sentence, never the error’s 
     const answer = await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
 
     assert.equal(code(answer), 'internal');
+    assert.equal(message(answer), INTERNAL_FAILURE, 'the wire carries the constant and nothing else');
     const said = JSON.stringify(answer.body);
     assert.ok(!said.includes('ENOENT'), said);
     assert.ok(!said.includes('id_ed25519_prod'), 'a path names a machine and an account');
     assert.ok(!said.includes('Connection.parse'), 'and a frame names the implementation');
+  } finally {
+    w.server.dispose();
+  }
+});
+
+test('a plain error leaks nothing either — the guarantee is the constant, not a filter', async () => {
+  // The case the negative-only assertion would have missed entirely.
+  const w = world({});
+  w.result = new Error('query failed: SELECT * FROM billing.card WHERE id=42');
+  try {
+    const { port, secret } = await share(w);
+
+    const answer = await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
+
+    assert.equal(message(answer), INTERNAL_FAILURE);
+    assert.ok(!JSON.stringify(answer.body).includes('billing.card'), 'a table name is machinery too');
   } finally {
     w.server.dispose();
   }
@@ -527,6 +550,10 @@ test('…and the journal keeps the reason, because that is where a person looks'
     const journal = w.audit.join('\n');
     assert.match(journal, /ENOENT/, 'the diagnosis moved here rather than disappearing');
     assert.match(journal, /uptime/, 'beside what was asked for');
+    // Three reviewers asked for this one: `respondError` has always taken the door a refusal came
+    // in by, and this call site was the one not passing it — so a refused use was the only kind of
+    // refusal the journal could not place. Asserted, or it can regress to `undefined` in silence.
+    assert.match(journal, /via token/, 'and the door it arrived by');
   } finally {
     w.server.dispose();
   }

--- a/src_vs_code/src/test/credsAgentServer.test.ts
+++ b/src_vs_code/src/test/credsAgentServer.test.ts
@@ -483,3 +483,51 @@ test('the listing is a GET only — a POST to it is not an action route', async 
     w.server.dispose();
   }
 });
+
+/**
+ * An internal failure tells the AGENT nothing about the implementation, and tells the JOURNAL
+ * everything.
+ *
+ * <p>CodeQL raised `js/stack-trace-exposure` (medium) here, and it was right about the shape even
+ * though the reader is a local agent rather than the internet: the caught error's own message went
+ * straight onto the wire. An `Error` from anywhere under `run` — a driver, a parser, a filesystem
+ * call — carries paths, versions, table names and query fragments, and this product's whole design
+ * treats an agent as a party that is told the RESULT and never the machinery.</p>
+ *
+ * <p>The half that must not be lost is the diagnosis, so it moves rather than disappearing: the
+ * journal line, which is local and is what a person reads when an agent reports a failure, now
+ * carries the real reason where it used to carry only the summary.</p>
+ */
+test('an internal failure gives the agent a fixed sentence, never the error’s own text', async () => {
+  const w = world({});
+  w.result = new Error('ENOENT: /home/dev/.ssh/id_ed25519_prod, open failed at Connection.parse:214');
+  try {
+    const { port, secret } = await share(w);
+
+    const answer = await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
+
+    assert.equal(code(answer), 'internal');
+    const said = JSON.stringify(answer.body);
+    assert.ok(!said.includes('ENOENT'), said);
+    assert.ok(!said.includes('id_ed25519_prod'), 'a path names a machine and an account');
+    assert.ok(!said.includes('Connection.parse'), 'and a frame names the implementation');
+  } finally {
+    w.server.dispose();
+  }
+});
+
+test('…and the journal keeps the reason, because that is where a person looks', async () => {
+  const w = world({});
+  w.result = new Error('ENOENT: /home/dev/.ssh/id_ed25519_prod, open failed');
+  try {
+    const { port, secret } = await share(w);
+
+    await call(port, '/v1/use/exec', { token: secret, body: { command: 'uptime' } });
+
+    const journal = w.audit.join('\n');
+    assert.match(journal, /ENOENT/, 'the diagnosis moved here rather than disappearing');
+    assert.match(journal, /uptime/, 'beside what was asked for');
+  } finally {
+    w.server.dispose();
+  }
+});


### PR DESCRIPTION
Closes the one open code-scanning alert on this repository: CodeQL `js/stack-trace-exposure`
(medium) at `credsAgentServer.ts:708`. The `catch` around a use-action's `run` passed
`describeError(error)` as the MESSAGE of the HTTP response, so the caught exception's own text went
onto the wire to the calling agent.

## Why it is a real defect and not only a scanner's opinion

The reader is a local process holding a grant token, not the internet, so the usual severity
argument is weaker. What makes it real is this product's own boundary: **an agent is a party told
the RESULT and never the machinery.** Everything else in this server is built that way — a secret is
used on the agent's behalf and never handed over, the masker strips values out of command output, a
refused call gets a code and a sentence. An `Error` from anywhere under `run` — a driver, a parser,
a filesystem call — carries paths, versions, table names and query fragments.

## What changed

- **The agent gets a constant**, `INTERNAL_FAILURE`. Not a redacted message — a fixed one, so there
  is nothing to leak by construction. The error CODE is unchanged (`internal`, HTTP 500), which is
  what an automated caller actually branches on.
- **The diagnosis MOVES rather than disappearing.** The journal is local and is what a person reads
  when an agent reports a failure; it now carries the reason beside what was asked for.
- **…and is masked on the way**, through the same masker the response body goes through. This was
  the review round's best finding and I had missed it: moving the error into the journal put it
  somewhere it had never been, and a driver's message is exactly where a credential turns up.
- **The refusal records which door it came in by.** `respondError` has always taken `via`; this call
  site was the one not passing it, so a refused USE was the only refusal the journal could not place.
- `INTERNAL_FAILURE` lives in `brokerProtocol.ts` beside `ErrorCode` and `errorBody` — where the
  wire's vocabulary is decided, and `credsAgentServer.ts` was AT its 800-line ceiling so the addition
  had to be paid for. The compaction took `perform` back under fifty lines, so half its lint
  suppression became stale and is gone.

## The review gate — run BEFORE this pull request

**Plan round:** 3 reviewers, 10 findings, verdict `good_enough`. Four accepted, and two of them
changed the tests for the better: my first assertions were NEGATIVE (no `ENOENT`, no key path, no
stack frame), which two reviewers independently called a filter where the guarantee is a CONSTANT —
`Error('query failed')` would have gone green on the unfixed code. Now an equality against
`INTERNAL_FAILURE`, plus a second case for exactly that plain error. Three reviewers separately asked
for the `via` value to be asserted; it is.

**Code round:** 9 reviewers, 11 findings, verdict **`proceed`**. One accepted — the masking above.

Rejected with reasons recorded in the gate, the three worth repeating here:

- *a length cap on the journalled reason* — checked and rejected **with the code**: `formatAuditLine`
  already truncates every detail to 200 characters through `oneLine`. I had written a 600-character
  cap for this finding and removed it on checking; at any larger number it could never fire, at a
  smaller one it would shorten every other detail. The test that was going to assert my cap asserts
  the formatter's instead, since that property lives in another module.
- *the HTTP contract doc was not updated* — that rule governs `serverTransport.ts` ↔ `Program.cs`,
  the extension talking to the vault SERVER. This is the local agent broker, whose shapes live in
  `brokerProtocol.ts` and whose clients are in this repository.
- *`via` is not passed* (raised twice) — both findings quote the line that passes it.

## Test plan — observed

The harness could express every outcome an action reaches by RETURNING and none it reaches by
FAILING, so the catch around `run` had no test at all. It gains one: `w.result` set to an `Error`
makes the action throw.

```
npm test    3204 tests · 3200 pass · 0 fail · 4 skipped
npm run lint       clean
npm run typecheck  clean
```

Five tests, each watched failing with the fix fully reverted:

| Asserted | Red without the fix |
|---|---|
| the wire message equals `INTERNAL_FAILURE` | it was `ENOENT: /home/dev/.ssh/id_ed25519_prod … at Connection.parse:214` |
| a plain error leaks nothing either | `query failed: SELECT * FROM billing.card WHERE id=42` reached the agent |
| the journal keeps the reason | the line read `internal  uptime`, with no reason in it |
| the journal records the door | no `via` at all |
| a secret inside the error is masked before journalling | it was written verbatim |
| a 5000-character message lands under 400 characters, ellipsised | (the formatter's property, pinned) |
