### PR TITLE
feat(org): the members registry on disk, and epic 1 after its two review rounds

### DIFF
--- a/research/module_server.md
+++ b/research/module_server.md
@@ -30,6 +30,10 @@ whole server is ~2,100 lines.
 | `src/OrgRecovery.cs` | The corporate-recovery roster, its quorum guard and its fingerprint |
 | `src/OrgRecoveryStore.cs` | Setup invites and the published org public key, on disk |
 | `src/OrgRecoveryMaintenance.cs` | Drops setup invites nobody acknowledged |
+| `src/OrgMembers.cs` | The members registry as records with no I/O: roles, share defaults, the three-state lookup, the policy derived from a role |
+| `src/OrgMembersStore.cs` | One record per person under `org/members/`, read synchronously from a stat-checked cache, written read-modify-write under the vault's per-email lock |
+| `src/OrgSettingsStore.cs` | The runtime settings an admin edits without a restart (`org/settings.json`); absent answers the default and writes nothing |
+| `src/OrgEventLog.cs` | The append-only NDJSON event log, one file per UTC day under `org/events/` — the writer only; the reader is a later epic's |
 | `src/Logging.cs` | Serilog wiring: the coloured console + the segmenting run file |
 | `src/AnsiConsoleSink.cs` | Hand-written ANSI colour (ported from the family — Serilog's own theme writes zero escapes once stdout is redirected, and a container's captured stdout always is) |
 | `src/DailyRunFileSink.cs` | A file per run, segmenting at UTC midnight (`00-00-00-<pid>.log` in the next day's folder) so a never-restarting container cannot grow one file for months |
@@ -435,6 +439,9 @@ ${DataDir}/org-recovery/invites/<key>/<guid>.json     one officer's sealed Shami
 ${DataDir}/org-recovery/ceremonies/<guid>.json        who ran a setup, and whom it invited
 ${DataDir}/org-recovery/sessions/<guid>.json          a live break-glass and its contributions
 ${DataDir}/org-recovery/audit.log                     NDJSON: who opened whose vault, never swept
+${DataDir}/org/members/<key>.json                     one person's registry record: role, flags, who changed it and when
+${DataDir}/org/settings.json                          the runtime settings an admin may change; absent means the defaults
+${DataDir}/org/events/<yyyy-MM-dd>.ndjson             the corporate event log, one file per UTC day, never swept
 ```
 
 `key = sha256(lowercased email) hex, first 32 chars` (128 bits). Hashed so a directory listing is
@@ -443,6 +450,27 @@ is here", and it is read defensively — a malformed or locked sidecar is skippe
 
 Every write is atomic: write `<path>.<random>.tmp`, then `File.Move(overwrite: true)`. A reader
 therefore never sees a partial blob, which is what lets `deploy/backup.sh` archive a live server.
+
+`org/` appears only when something is written into it — a personal deployment never has one, which is
+how an operator looking at the disk can tell a server with a roster from one without. Three things
+about what is under it, none of which has an endpoint yet:
+
+- **A member record this build cannot read is *unavailable*, never *not registered*.** Not registered
+  means the default role, and the default may export, so a malformed file, an unreadable one, or one
+  whose `schemaVersion` is above this build's would otherwise promote its owner; every caller fails
+  closed instead, and the log names the file at Error, once. A field this build does not know is
+  carried and written back rather than dropped, so an older instance cannot strip what a newer one
+  wrote. Lookups are synchronous, from an in-memory cache that re-stats the file first — a record
+  changed by a restore or a second instance is seen on the next lookup; writes are read-modify-write
+  under the same per-email lock as `PUT /api/vault`, so two admins editing one person cannot lose an
+  edit.
+- **A settings file this build cannot read answers the default** (a 24-hour offline lease), logged
+  once — nothing in it grants a permission, and refusing everybody over it would be an outage.
+- **The event log takes one dedicated lock with a five-second bound** — every writer appends to the
+  same day file, so the vault's stripe would race — and a failed append never fails the mutation it
+  records: it answers false and logs at Error naming the file. A torn final line from a killed process
+  gets a newline before the next row, so the reader loses one row rather than two. Neither maintenance
+  sweep touches `org/events/`; a test pins it.
 
 ### Known limits
 
@@ -461,8 +489,9 @@ therefore never sees a partial blob, which is what lets `deploy/backup.sh` archi
 
 ## Tests
 
-`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 68 tests, ~1.5 s, entirely
-in-process through `WebApplicationFactory`. No free port, no background `dotnet run`.
+`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 189 tests, ~5 s. The
+endpoint suites run in-process through `WebApplicationFactory` — no free port, no background
+`dotnet run`; the store suites drive a store directly on a throwaway data directory.
 
 ```bash
 dotnet build dew_flow_creds_for_devs.slnx
@@ -485,6 +514,9 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 | `ConcurrencyTests` | `If-Match`/`If-None-Match` optimistic-concurrency semantics on `PUT /api/vault` |
 | `InstanceFileTests` | The instance-file publish/withdraw lifecycle |
 | `ClientConfigTests`, `HealthProbeUrlTests` | (nested in `HealthTests.cs`) the advertised scope, and the probe URL |
+| `OrgMembersStoreTests` | The registry: answered from the cache, the stat check sees an outside write, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), schema version, unknown fields carried, no `org/` until a write |
+| `OrgSettingsStoreTests` | The default without a file and no write, write then read, a malformed file answers the default once-logged, an outside write is seen |
+| `OrgEventLogTests` | Append and read back, the UTC day boundary, a torn tail gets its newline, the bounded lock, an unwritable folder is logged not thrown, both sweeps leave `org/events/` alone |
 
 Configuration reaches the app through **process environment variables**, not
 `WithWebHostBuilder` — `Program.cs` reads `builder.Configuration` before `Build()`, so anything a

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -442,6 +442,7 @@ ${DataDir}/org-recovery/audit.log                     NDJSON: who opened whose v
 ${DataDir}/org/members/<key>.json                     one person's registry record: role, flags, who changed it and when
 ${DataDir}/org/settings.json                          the runtime settings an admin may change; absent means the defaults
 ${DataDir}/org/events/<yyyy-MM-dd>.ndjson             the corporate event log, one file per UTC day, never swept
+${DataDir}/org/events/.append.lock                    zero bytes; held exclusively for the length of one append, across processes
 ```
 
 `key = sha256(lowercased email) hex, first 32 chars` (128 bits). Hashed so a directory listing is
@@ -456,21 +457,33 @@ how an operator looking at the disk can tell a server with a roster from one wit
 about what is under it, none of which has an endpoint yet:
 
 - **A member record this build cannot read is *unavailable*, never *not registered*.** Not registered
-  means the default role, and the default may export, so a malformed file, an unreadable one, or one
-  whose `schemaVersion` is above this build's would otherwise promote its owner; every caller fails
-  closed instead, and the log names the file at Error, once. A field this build does not know is
-  carried and written back rather than dropped, so an older instance cannot strip what a newer one
-  wrote. Lookups are synchronous, from an in-memory cache that re-stats the file first — a record
-  changed by a restore or a second instance is seen on the next lookup; writes are read-modify-write
-  under the same per-email lock as `PUT /api/vault`, so two admins editing one person cannot lose an
-  edit.
-- **A settings file this build cannot read answers the default** (a 24-hour offline lease), logged
-  once — nothing in it grants a permission, and refusing everybody over it would be an outage.
-- **The event log takes one dedicated lock with a five-second bound** — every writer appends to the
-  same day file, so the vault's stripe would race — and a failed append never fails the mutation it
-  records: it answers false and logs at Error naming the file. A torn final line from a killed process
-  gets a newline before the next row, so the reader loses one row rather than two. Neither maintenance
-  sweep touches `org/events/`; a test pins it.
+  means the default role, and the default may export, so a malformed file, an unreadable one, one
+  whose `schemaVersion` is above this build's (however many of its fields this build recognises), or a
+  well-formed record whose email does not hash to the file it sits in — a restore that mixed two files
+  — would otherwise promote its owner or hand them a colleague's role; every caller fails closed
+  instead, and the log names the file at Error, once. A field this build does not know is carried and
+  written back rather than dropped, so an older instance cannot strip what a newer one wrote. Lookups
+  are synchronous, from an in-memory cache that re-stats the file first — a record changed by a restore
+  or a second instance is seen on the next lookup, and "no file" is cached the same way, so a person
+  who never synced costs one exception once, not per request; writes are read-modify-write under the
+  same per-email lock as `PUT /api/vault`, so two admins editing one person cannot lose an edit.
+- **A settings file that exists but cannot be read answers the last value this process read or
+  wrote**, and only a process that never had one answers the default (a 24-hour offline lease) —
+  because an admin who set the lease to `0`, strictly online, must not have every client handed 24
+  hours back by a permission flip. Absent still answers the default and writes nothing. Either way the
+  log names the file at Error, once, and says which value is being answered; refusing everybody over
+  this file would be an outage.
+- **The event log takes one dedicated lock in two halves, with one five-second bound** — an in-process
+  semaphore, and `org/events/.append.lock` opened exclusively across processes, because every writer
+  appends to the same day file, so the vault's stripe would race — and a failed append never fails the
+  mutation it records: it answers false and logs at Error naming the file, the kind, the actor and the
+  subject, so the trail degrades to the server log rather than vanishing. The day file is opened for
+  append with shared read-write, so a second instance during a rolling restart appends rather than
+  losing its row and a reader never blocks a writer; the lock file exists because that alone is not
+  an atomic append in .NET — measured: 71 of 400 rows from two instances overwritten while every
+  append reported success. A torn final line from a killed process gets a newline before the next
+  row, so the reader loses one row rather than two. Neither maintenance sweep touches `org/events/`;
+  a test pins it.
 
 ### Known limits
 
@@ -489,7 +502,7 @@ about what is under it, none of which has an endpoint yet:
 
 ## Tests
 
-`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 189 tests, ~5 s. The
+`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 207 tests, ~8 s. The
 endpoint suites run in-process through `WebApplicationFactory` — no free port, no background
 `dotnet run`; the store suites drive a store directly on a throwaway data directory.
 
@@ -514,9 +527,10 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 | `ConcurrencyTests` | `If-Match`/`If-None-Match` optimistic-concurrency semantics on `PUT /api/vault` |
 | `InstanceFileTests` | The instance-file publish/withdraw lifecycle |
 | `ClientConfigTests`, `HealthProbeUrlTests` | (nested in `HealthTests.cs`) the advertised scope, and the probe URL |
-| `OrgMembersStoreTests` | The registry: answered from the cache, the stat check sees an outside write, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), schema version, unknown fields carried, no `org/` until a write |
-| `OrgSettingsStoreTests` | The default without a file and no write, write then read, a malformed file answers the default once-logged, an outside write is seen |
-| `OrgEventLogTests` | Append and read back, the UTC day boundary, a torn tail gets its newline, the bounded lock, an unwritable folder is logged not thrown, both sweeps leave `org/events/` alone |
+| `MemberPolicyTests` | The role → policy table: admin and member unrestricted whatever the share default, both developer share defaults, an unknown role or share default gets the most restrictive policy, the default role is member |
+| `OrgMembersStoreTests` | The registry: answered from the cache (a missing record too), the stat check sees an outside write and a record that appears, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), a record whose email does not hash to its file is unavailable, schema version — with only known fields too — refuses whole, unknown fields carried, `@domain` accepted, no `org/` until a write |
+| `OrgSettingsStoreTests` | The default without a file and no write, write then read, a malformed or unopenable file answers the last value this process read (the default only when it never read one), logged once, an outside write is seen |
+| `OrgEventLogTests` | Append and read back, the UTC day boundary, a torn tail gets its newline, the bounded lock, an unwritable folder is logged not thrown, two instances over one directory lose no row, both sweeps leave `org/events/` alone |
 
 Configuration reaches the app through **process environment variables**, not
 `WithWebHostBuilder` — `Program.cs` reads `builder.Configuration` before `Build()`, so anything a

--- a/src_minimalapi_server/src/AppJsonContext.cs
+++ b/src_minimalapi_server/src/AppJsonContext.cs
@@ -56,6 +56,9 @@ public sealed record ClientConfigDto(string MicrosoftScope);
 [JsonSerializable(typeof(StartSessionRequest))]
 [JsonSerializable(typeof(ContributeRequest))]
 [JsonSerializable(typeof(AuditEntryDto))]
+[JsonSerializable(typeof(MemberRecord))]
+[JsonSerializable(typeof(OrgSettingsDto))]
+[JsonSerializable(typeof(OrgEventDto))]
 public sealed partial class AppJsonContext : JsonSerializerContext;
 
 /// <summary>The instance file's contract, indented for the human who opens it.</summary>

--- a/src_minimalapi_server/src/OrgEventLog.cs
+++ b/src_minimalapi_server/src/OrgEventLog.cs
@@ -1,0 +1,168 @@
+using System.Globalization;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace CredVaultServer;
+
+/// <summary>
+/// One row of the corporate event log. Metadata only, by the umbrella's invariant: an entity NAME and
+/// KIND, which a share already carries in plaintext, and never content. The shape belongs to the
+/// event-log epic, which owns the reader; it is defined here because the writer ships first, so that
+/// the registry, blocking and projects record from their first commit.
+/// </summary>
+public sealed record OrgEventDto(
+    long At,
+    string Kind,
+    string Actor,
+    string? Subject,
+    string? Project,
+    string? ShareId,
+    string? EntityName,
+    string? EntityKind,
+    string? Outcome,
+    string? Detail);
+
+/// <summary>
+/// The kinds this epic emits. The union of every epic's kinds lives in the event-log plan; a kind is
+/// a string on the wire so an older reader shows one it does not know rather than dropping the row.
+/// </summary>
+public static class OrgEventKinds
+{
+    /// <summary>
+    /// A record was CREATED. Two emitters, one kind: the sync hook, with the person as the actor, and an
+    /// admin who sets a role before the person's first sync, with the admin as the actor.
+    /// </summary>
+    public const string MemberRegistered = "member.registered";
+
+    public const string MemberRoleChanged = "member.role_changed";
+
+    public const string MemberShareDefaultChanged = "member.share_default_changed";
+
+    public const string SettingsChanged = "settings.changed";
+}
+
+/// <summary>
+/// Append-only NDJSON at <c>${DataDir}/org/events/&lt;yyyy-MM-dd&gt;.ndjson</c>, one file per UTC day.
+///
+/// <para><b>Its own root, never under <c>org-recovery/</c>.</b> Both maintenance sweeps walk named
+/// subdirectories, which is precisely why the break-glass audit log has survived; a log parked under a
+/// folder somebody might one day enumerate wholesale is a log with a deletion waiting for it. A test
+/// pins that both sweeps leave this folder alone. Kept forever, by owner decision 11: about 50 KB a
+/// day, 18 MB a year, on the same disk as the vaults.</para>
+///
+/// <para><b>One dedicated lock, not the vault's stripe of 64.</b> Striping works when writers touch
+/// different files; here every writer in the process appends to the same day file, so a "per-file
+/// lock" is this lock under another name, and a stripe would race inside one day. <b>The wait is
+/// bounded</b> at <see cref="DefaultLockWait"/>: an unbounded wait on a request path is how one stuck
+/// writer becomes a stalled server. Past the bound the row is abandoned under the rule below.</para>
+///
+/// <para><b>A failed append never fails its caller.</b> The row is written AFTER the mutation has
+/// landed, so a role change that happened must not be reported as a <c>500</c> — a client that retried
+/// would be acting on a lie. <see cref="AppendAsync"/> answers <c>false</c> and logs at Error naming the
+/// file, which is the operator's signal that the log has stopped recording.</para>
+///
+/// <para><b>The appender guarantees the shape of the file, not the reader's tolerance of it.</b> When
+/// the file's last byte is not a newline — a process killed mid-append — a newline goes first, so the
+/// torn row and the new one cannot fuse into one unparseable line; the reader then loses one row where
+/// it would have lost two. The break-glass audit log's bare <c>File.AppendAllTextAsync</c> is the
+/// precedent for the format, not for the locking: a recovery is rare, a role change is not.</para>
+///
+/// <para>The day is the clock's at append time, and the clock is injected so a day boundary is a test
+/// rather than a wait until midnight.</para>
+/// </summary>
+public sealed class OrgEventLog(
+    string dataDir,
+    ILogger<OrgEventLog> log,
+    Func<DateTimeOffset> clock,
+    TimeSpan? lockWait = null)
+{
+    public static readonly TimeSpan DefaultLockWait = TimeSpan.FromSeconds(5);
+
+    private static readonly byte[] Newline = "\n"u8.ToArray();
+
+    private readonly string _dir = Path.Combine(dataDir, "org", "events");
+    private readonly TimeSpan _lockWait = lockWait ?? DefaultLockWait;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    /// <summary>
+    /// The day file a row appended at <paramref name="at"/> lands in — the UTC day, whatever offset the
+    /// value carries. Public so a reader, and a test, asks the log for the name rather than guessing it.
+    /// </summary>
+    public string PathForDay(DateTimeOffset at) =>
+        Path.Combine(_dir, at.UtcDateTime.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture) + ".ndjson");
+
+    /// <summary>Held from a test to prove the wait is bounded; nothing in the server touches this.</summary>
+    internal SemaphoreSlim Gate => _gate;
+
+    /// <summary>
+    /// Append one row. Never throws; <c>false</c> means the row was lost, and the log names the file.
+    /// </summary>
+    public async Task<bool> AppendAsync(OrgEventDto row, CancellationToken ct)
+    {
+        var path = PathForDay(clock());
+        if (!await TryEnterAsync(path, ct))
+        {
+            return false;
+        }
+        try
+        {
+            Directory.CreateDirectory(_dir);
+            await WriteRowAsync(path, JsonSerializer.SerializeToUtf8Bytes(row, AppJsonContext.Default.OrgEventDto), ct);
+            return true;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or OperationCanceledException)
+        {
+            log.LogError(e, "event log {Path}: a {Kind} row was lost; the log has stopped recording", path, row.Kind);
+            return false;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private async Task<bool> TryEnterAsync(string path, CancellationToken ct)
+    {
+        try
+        {
+            if (await _gate.WaitAsync(_lockWait, ct))
+            {
+                return true;
+            }
+            log.LogError(
+                "event log {Path}: the writer lock was not free within {Wait}; a row was abandoned rather than stall the request",
+                path,
+                _lockWait);
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            log.LogError("event log {Path}: the request was cancelled while waiting for the writer lock; a row was abandoned", path);
+            return false;
+        }
+    }
+
+    /// <summary>One write per row, so a crash costs at most the row being written.</summary>
+    private static async Task WriteRowAsync(string path, byte[] row, CancellationToken ct)
+    {
+        await using var stream = new FileStream(
+            path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, bufferSize: 0, useAsync: true);
+        byte[] separator = await EndsMidLineAsync(stream, ct) ? Newline : [];
+        byte[] line = [.. separator, .. row, .. Newline];
+        stream.Seek(0, SeekOrigin.End);
+        await stream.WriteAsync(line, ct);
+        await stream.FlushAsync(ct);
+    }
+
+    private static async Task<bool> EndsMidLineAsync(FileStream stream, CancellationToken ct)
+    {
+        if (stream.Length == 0)
+        {
+            return false;
+        }
+        stream.Seek(-1, SeekOrigin.End);
+        var last = new byte[1];
+        await stream.ReadExactlyAsync(last, ct);
+        return last[0] != (byte)'\n';
+    }
+}

--- a/src_minimalapi_server/src/OrgEventLog.cs
+++ b/src_minimalapi_server/src/OrgEventLog.cs
@@ -50,16 +50,21 @@ public static class OrgEventKinds
 /// pins that both sweeps leave this folder alone. Kept forever, by owner decision 11: about 50 KB a
 /// day, 18 MB a year, on the same disk as the vaults.</para>
 ///
-/// <para><b>One dedicated lock, not the vault's stripe of 64.</b> Striping works when writers touch
-/// different files; here every writer in the process appends to the same day file, so a "per-file
-/// lock" is this lock under another name, and a stripe would race inside one day. <b>The wait is
-/// bounded</b> at <see cref="DefaultLockWait"/>: an unbounded wait on a request path is how one stuck
-/// writer becomes a stalled server. Past the bound the row is abandoned under the rule below.</para>
+/// <para><b>One dedicated lock, in two halves, not the vault's stripe of 64.</b> Striping works when
+/// writers touch different files; here every writer appends to the same day file, so a "per-file lock"
+/// is this lock under another name, and a stripe would race inside one day. The in-process half is a
+/// <see cref="SemaphoreSlim"/>; the cross-process half is <c>.append.lock</c> in the same folder, opened
+/// exclusively for the length of one probe and one write, because a rolling restart has two instances
+/// writing the same day file for a while and the file system gives them no ordering on its own (see
+/// <see cref="WriteRowAsync"/> for what was measured). <b>The wait is bounded</b> — both halves share one
+/// deadline of <see cref="DefaultLockWait"/> — because an unbounded wait on a request path is how one
+/// stuck writer becomes a stalled server. Past the bound the row is abandoned under the rule below.</para>
 ///
 /// <para><b>A failed append never fails its caller.</b> The row is written AFTER the mutation has
 /// landed, so a role change that happened must not be reported as a <c>500</c> — a client that retried
 /// would be acting on a lie. <see cref="AppendAsync"/> answers <c>false</c> and logs at Error naming the
-/// file, which is the operator's signal that the log has stopped recording.</para>
+/// file, the kind, the actor and the subject, so that the trail degrades to the server log rather than
+/// vanishing; that line is the operator's signal that the log has stopped recording.</para>
 ///
 /// <para><b>The appender guarantees the shape of the file, not the reader's tolerance of it.</b> When
 /// the file's last byte is not a newline — a process killed mid-append — a newline goes first, so the
@@ -78,9 +83,13 @@ public sealed class OrgEventLog(
 {
     public static readonly TimeSpan DefaultLockWait = TimeSpan.FromSeconds(5);
 
+    /// <summary>How long a writer sleeps between attempts on the cross-process lock. A write holds it for microseconds.</summary>
+    private static readonly TimeSpan LockPoll = TimeSpan.FromMilliseconds(5);
+
     private static readonly byte[] Newline = "\n"u8.ToArray();
 
     private readonly string _dir = Path.Combine(dataDir, "org", "events");
+    private readonly string _lockPath = Path.Combine(dataDir, "org", "events", ".append.lock");
     private readonly TimeSpan _lockWait = lockWait ?? DefaultLockWait;
     private readonly SemaphoreSlim _gate = new(1, 1);
 
@@ -100,19 +109,29 @@ public sealed class OrgEventLog(
     public async Task<bool> AppendAsync(OrgEventDto row, CancellationToken ct)
     {
         var path = PathForDay(clock());
-        if (!await TryEnterAsync(path, ct))
+        var deadline = DateTime.UtcNow + _lockWait;
+        if (!await TryEnterAsync(path, row, deadline, ct))
         {
             return false;
         }
         try
         {
             Directory.CreateDirectory(_dir);
+            await using var held = await HoldAcrossProcessesAsync(deadline, ct);
             await WriteRowAsync(path, JsonSerializer.SerializeToUtf8Bytes(row, AppJsonContext.Default.OrgEventDto), ct);
             return true;
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException or OperationCanceledException)
         {
-            log.LogError(e, "event log {Path}: a {Kind} row was lost; the log has stopped recording", path, row.Kind);
+            // Actor and subject ride along so that when the NDJSON append fails the trail degrades to
+            // the server log instead of vanishing.
+            log.LogError(
+                e,
+                "event log {Path}: a {Kind} row by {Actor} about {Subject} was lost; the log has stopped recording",
+                path,
+                row.Kind,
+                row.Actor,
+                row.Subject ?? "(nobody)");
             return false;
         }
         finally
@@ -121,48 +140,102 @@ public sealed class OrgEventLog(
         }
     }
 
-    private async Task<bool> TryEnterAsync(string path, CancellationToken ct)
+    private async Task<bool> TryEnterAsync(string path, OrgEventDto row, DateTime deadline, CancellationToken ct)
     {
         try
         {
-            if (await _gate.WaitAsync(_lockWait, ct))
+            if (await _gate.WaitAsync(Remaining(deadline), ct))
             {
                 return true;
             }
             log.LogError(
-                "event log {Path}: the writer lock was not free within {Wait}; a row was abandoned rather than stall the request",
+                "event log {Path}: the writer lock was not free within {Wait}; a {Kind} row by {Actor} about {Subject} was abandoned rather than stall the request",
                 path,
-                _lockWait);
+                _lockWait,
+                row.Kind,
+                row.Actor,
+                row.Subject ?? "(nobody)");
             return false;
         }
         catch (OperationCanceledException)
         {
-            log.LogError("event log {Path}: the request was cancelled while waiting for the writer lock; a row was abandoned", path);
+            log.LogError(
+                "event log {Path}: the request was cancelled while waiting for the writer lock; a {Kind} row by {Actor} about {Subject} was abandoned",
+                path,
+                row.Kind,
+                row.Actor,
+                row.Subject ?? "(nobody)");
             return false;
         }
     }
 
-    /// <summary>One write per row, so a crash costs at most the row being written.</summary>
+    private static TimeSpan Remaining(DateTime deadline)
+    {
+        var left = deadline - DateTime.UtcNow;
+        return left > TimeSpan.Zero ? left : TimeSpan.Zero;
+    }
+
+    /// <summary>
+    /// The cross-process half of the lock: an exclusive handle on <c>.append.lock</c>, retried every
+    /// <see cref="LockPoll"/> until the shared deadline. Past it the sharing violation propagates and the
+    /// row is abandoned under the never-fail-the-caller rule, with the log naming the file. A separate
+    /// file rather than the day file itself, so that readers — the query, an operator's <c>tail</c> — are
+    /// never refused by a writer.
+    /// </summary>
+    private async Task<FileStream> HoldAcrossProcessesAsync(DateTime deadline, CancellationToken ct)
+    {
+        while (true)
+        {
+            try
+            {
+                return new FileStream(
+                    _lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None, bufferSize: 1, FileOptions.None);
+            }
+            catch (IOException) when (DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(LockPoll, ct);
+            }
+        }
+    }
+
+    /// <summary>
+    /// One write per row, so a crash costs at most the row being written.
+    ///
+    /// <para>Opened for append with <see cref="FileShare.ReadWrite"/>, and the torn-tail probe is a
+    /// separate short read opened the same way. What this buys: a second instance — a rolling restart
+    /// has two for a while — can open the same day file at all and append instead of being refused and
+    /// losing its row, and a reader holding the file open never blocks a writer.</para>
+    ///
+    /// <para>What it does NOT buy, measured before <c>.append.lock</c> existed: an atomic append. .NET's
+    /// <see cref="FileMode.Append"/> is <see cref="FileMode.OpenOrCreate"/> plus a seek to the end at open
+    /// time — no <c>O_APPEND</c>, no <c>FILE_APPEND_DATA</c> — so two writers that opened at the same
+    /// length wrote at the same offset, and 71 of 400 rows from two instances were overwritten while
+    /// every one of them reported success. The lock file is what serialises writers across processes;
+    /// this method assumes the caller holds it. What remains true, and is fine: two processes interleave
+    /// whole rows, which NDJSON tolerates by construction — one row per line, none depending on the
+    /// one before.</para>
+    /// </summary>
     private static async Task WriteRowAsync(string path, byte[] row, CancellationToken ct)
     {
-        await using var stream = new FileStream(
-            path, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read, bufferSize: 0, useAsync: true);
-        byte[] separator = await EndsMidLineAsync(stream, ct) ? Newline : [];
+        byte[] separator = await EndsMidLineAsync(path, ct) ? Newline : [];
         byte[] line = [.. separator, .. row, .. Newline];
-        stream.Seek(0, SeekOrigin.End);
+        await using var stream = new FileStream(
+            path, FileMode.Append, FileAccess.Write, FileShare.ReadWrite, bufferSize: 0, useAsync: true);
         await stream.WriteAsync(line, ct);
         await stream.FlushAsync(ct);
     }
 
-    private static async Task<bool> EndsMidLineAsync(FileStream stream, CancellationToken ct)
+    private static async Task<bool> EndsMidLineAsync(string path, CancellationToken ct)
     {
-        if (stream.Length == 0)
+        await using var probe = new FileStream(
+            path, FileMode.OpenOrCreate, FileAccess.Read, FileShare.ReadWrite, bufferSize: 0, useAsync: true);
+        if (probe.Length == 0)
         {
             return false;
         }
-        stream.Seek(-1, SeekOrigin.End);
+        probe.Seek(-1, SeekOrigin.End);
         var last = new byte[1];
-        await stream.ReadExactlyAsync(last, ct);
+        await probe.ReadExactlyAsync(last, ct);
         return last[0] != (byte)'\n';
     }
 }

--- a/src_minimalapi_server/src/OrgMembers.cs
+++ b/src_minimalapi_server/src/OrgMembers.cs
@@ -1,0 +1,269 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CredVaultServer;
+
+/// <summary>
+/// Who the people on this server are, as records with no I/O.
+///
+/// <para>The server's model of a person used to be one sentence: the email in a verified token.
+/// That is the right model for a team of peers and the wrong one for a company, where somebody
+/// administers, somebody may not export, and somebody has left. This file is that second model —
+/// deliberately small and free of behaviour, so the rules over it are pure functions and therefore
+/// tests.</para>
+///
+/// <para><b>Nothing here is a secret.</b> A role, a flag, a project id and a timestamp: the same
+/// class of data as the recovery roster, which this server already stores in plaintext because it
+/// has to act on it. No field in this file could help anybody decrypt anything, which is what keeps
+/// the whole corporate surface on the right side of rule 1.</para>
+/// </summary>
+public static class MemberRole
+{
+    /// <summary>May manage people, projects and settings, and read the whole event log.</summary>
+    public const string Admin = "admin";
+
+    /// <summary>What every account is today — and the default for everyone, see below.</summary>
+    public const string Member = "member";
+
+    /// <summary>A developer: no export, no local backup, sharing only inside a project.</summary>
+    public const string Dev = "dev";
+
+    /// <summary>
+    /// The role a person has before anybody has said otherwise.
+    ///
+    /// <para><b><c>member</c>, and that is a decision rather than a fallback.</b> The alternative —
+    /// default to <c>dev</c> so nothing is permitted until an admin permits it — would mean that on
+    /// the day a server gains a recovery roster, every colleague loses export and sharing at once,
+    /// over a role nobody assigned them. A control plane that changes what people may do before
+    /// anyone has configured it is a control plane that gets switched off.</para>
+    /// </summary>
+    public const string Default = Member;
+
+    public static bool IsKnown(string? role) => role is Admin or Member or Dev;
+}
+
+/// <summary>
+/// What a developer may do about sharing when no project assignment says otherwise.
+/// </summary>
+/// <remarks>
+/// Plural, unlike the property it fills: a type and a property of the same name compile only
+/// under fully qualified references, and code that has to name its own namespace to say
+/// <c>ShareDefault.Project</c> reads as though something clever is happening. Nothing is.
+/// </remarks>
+public static class ShareDefaults
+{
+    /// <summary>May share, but only inside a project both people belong to.</summary>
+    public const string Project = "project";
+
+    /// <summary>May receive shares and send none.</summary>
+    public const string None = "none";
+
+    public const string Default = Project;
+
+    /// <summary>What the server reports for a role that is not a developer at all.</summary>
+    public const string Any = "any";
+
+    public static bool IsKnown(string? value) => value is Project or None;
+}
+
+/// <summary>How one project assignment modifies a developer's own share default.</summary>
+public static class ProjectShare
+{
+    public const string Inherit = "inherit";
+    public const string Allow = "allow";
+    public const string Deny = "deny";
+
+    public const string Default = Inherit;
+
+    public static bool IsKnown(string? value) => value is Inherit or Allow or Deny;
+}
+
+/// <summary>One person's assignment to one project. Epic 3 gives it behaviour.</summary>
+public sealed record ProjectAssignment(string ProjectId, string Share);
+
+/// <summary>
+/// An instruction the client has not carried out yet: remove this project's folder from the
+/// person's own vault. Epic 3 gives it behaviour; the field is reserved here so the record's shape
+/// does not change under a store that is already writing files.
+/// </summary>
+public sealed record PendingFolderRemoval(string ProjectId, bool DeleteFolder, long At);
+
+/// <summary>
+/// One person, as this server knows them.
+/// </summary>
+/// <remarks>
+/// <para>Fields whose BEHAVIOUR belongs to a later epic are still written here, each with a value
+/// meaning "nothing has happened yet": <c>Active</c> and <c>LoginKeyVersion</c> (epic 2, blocking
+/// and the login key), <c>Projects</c> and <c>PendingFolderRemovals</c> (epic 3). Reserving them
+/// costs a few bytes per person; adding them later would mean a migration across records this
+/// store has already written, which is the more expensive half of the same decision.</para>
+/// <para><b>A record from a NEWER build must round-trip through this one.</b> <c>SchemaVersion</c>
+/// says whether this build may act on a record at all; <see cref="Unknown"/> carries whatever a newer
+/// build added, so that writing the record back — which every role change does — strips nothing.
+/// The extension learned the same rule about key wraps: a wrap this build cannot use is one it must
+/// carry.</para>
+/// </remarks>
+public sealed record MemberRecord(
+    int SchemaVersion,
+    string Email,
+    string Role,
+    bool Active,
+    string ShareDefault,
+    IReadOnlyList<ProjectAssignment> Projects,
+    IReadOnlyList<PendingFolderRemoval> PendingFolderRemovals,
+    int LoginKeyVersion,
+    long UpdatedAt,
+    string UpdatedBy)
+{
+    /// <summary>
+    /// The version this build writes, and the highest it will read.
+    ///
+    /// <para>Bumped only when a change alters what an OLDER build would DO with a record — a field
+    /// whose absence changes a permission, a value that means something new. A new optional field does
+    /// not bump it: an older build carries it in <see cref="Unknown"/> and writes it back untouched, and
+    /// bumping for an additive change would lock every older instance out of every record for no
+    /// protection gained. A record without the field reads as <c>0</c> and is accepted — it names
+    /// nothing this build does not know.</para>
+    /// </summary>
+    public const int CurrentSchemaVersion = 1;
+
+    /// <summary>
+    /// Properties this build does not know, carried so it can write them back.
+    ///
+    /// <para><see cref="System.Text.Json"/> drops an unknown property in silence, so an older server
+    /// reading a record a newer one wrote and writing it back would strip whatever the newer build
+    /// added, and nothing would notice.</para>
+    /// <para>In the body, with a plain <c>set</c>, and both halves are forced. The serializer refuses an
+    /// extension-data property that binds to a constructor argument; and the source generator turns an
+    /// <c>init</c>-only property that is not a constructor parameter into exactly such an argument (an
+    /// object-initializer pseudo-parameter — read off the generated metadata, where it appeared as
+    /// <c>Position = 10</c>). So <c>init</c> fails at runtime the same way a positional parameter does.
+    /// Nothing in this repository assigns it; <c>with</c> copies it like any other member.</para>
+    /// </summary>
+    [JsonExtensionData]
+    public IDictionary<string, JsonElement>? Unknown { get; set; }
+
+    /// <summary>
+    /// The record a person has before one is written for them.
+    ///
+    /// <para>Computed rather than persisted, so <c>GET /api/org/me</c> answers correctly for a
+    /// caller who has never synced without creating a file for a token that stored nothing. The
+    /// same discipline as <see cref="OrgRecoveryConfig"/>'s "off is the shape, not a flag".</para>
+    /// </summary>
+    public static MemberRecord DefaultFor(string email, long now) => new(
+        SchemaVersion: CurrentSchemaVersion,
+        Email: Normalize(email),
+        Role: MemberRole.Default,
+        Active: true,
+        ShareDefault: ShareDefaults.Default,
+        Projects: [],
+        PendingFolderRemovals: [],
+        LoginKeyVersion: 0,
+        UpdatedAt: now,
+        UpdatedBy: string.Empty);
+
+    /// <summary>One spelling of an email across the whole registry, and the one the key is cut from.</summary>
+    public static string Normalize(string email) => email.Trim().ToLowerInvariant();
+
+    /// <summary>
+    /// Whether a record read off disk is one this build can act on.
+    /// </summary>
+    /// <remarks>
+    /// <para>A record that fails this is <see cref="MemberLookup.Unavailable"/> — never "not
+    /// registered", and not a person with no rights either. The first draft of this remark said a
+    /// malformed record "is treated as not registered, which means the default", and the review round
+    /// showed that sentence to be a privilege escalation in a defensive coat: the default is
+    /// <c>member</c>, and a member may export, so corrupting one file promoted a developer.</para>
+    /// <para>Every caller fails closed instead: the admin gate refuses, <c>GET /api/org/me</c> answers
+    /// <c>503</c>, and the log names the file at Error. One bad file costs one person a refusal an
+    /// operator can fix — not the company a permission nobody granted.</para>
+    /// </remarks>
+    public bool IsWellFormed() =>
+        !string.IsNullOrWhiteSpace(Email)
+        && MemberRole.IsKnown(Role)
+        && ShareDefaults.IsKnown(ShareDefault)
+        && Projects is not null
+        && PendingFolderRemovals is not null;
+}
+
+/// <summary>
+/// The three answers a registry lookup can give — and the reason there are three.
+/// </summary>
+/// <remarks>
+/// <list type="bullet">
+/// <item><b><see cref="Found"/></b> — a record this build can act on.</item>
+/// <item><b><see cref="NotRegistered"/></b> — no file. The person has never synced, so the computed
+/// default applies; that is why <c>GET /api/org/me</c> can answer before the disk agrees.</item>
+/// <item><b><see cref="Unavailable"/></b> — a file exists and this build could not read it: malformed
+/// JSON, an I/O error, a schema version it refuses. Every caller fails CLOSED — the admin gate refuses,
+/// <c>GET /api/org/me</c> answers <c>503</c> with <c>Retry-After</c>, and the log names the file at
+/// Error. A refusal a person can see and an operator can fix beats a silent promotion nobody can.</item>
+/// </list>
+/// <para>Two answers would have been the natural shape, and "unreadable means not registered" the
+/// natural mapping. It is the escalation described on <see cref="MemberRecord.IsWellFormed"/>: a
+/// corrupt file — a half-written record, a bad sector, a restore from a truncated archive — would turn
+/// a developer into a member. The third state exists so that no caller can collapse it back to two.</para>
+/// </remarks>
+public enum MemberLookup
+{
+    Found,
+    NotRegistered,
+    Unavailable,
+}
+
+/// <summary>
+/// A lookup's answer. <see cref="Record"/> is present exactly when <see cref="Status"/> is
+/// <see cref="MemberLookup.Found"/>; callers switch on the status, never on the null — a null here is
+/// what the escalation above was made of.
+/// </summary>
+public readonly record struct MemberLookupResult(MemberLookup Status, MemberRecord? Record)
+{
+    public static MemberLookupResult Found(MemberRecord record) => new(MemberLookup.Found, record);
+
+    public static MemberLookupResult NotRegistered => new(MemberLookup.NotRegistered, null);
+
+    public static MemberLookupResult Unavailable => new(MemberLookup.Unavailable, null);
+}
+
+/// <summary>
+/// What an upsert did: the record as written, and whether it CREATED it. Two callers emit
+/// <c>member.registered</c> only on a create — the sync hook, and an admin who sets a role before the
+/// person's first sync — and neither can tell from the record alone.
+/// </summary>
+public readonly record struct UpsertResult(MemberRecord Record, bool Created);
+
+/// <summary>
+/// What a client may do, derived from the role every time it is asked.
+/// </summary>
+/// <remarks>
+/// <para><b>Derived, never stored.</b> A stored copy of a rule is a second source of truth, and the
+/// two drift the first time somebody changes the rule without migrating the copies.</para>
+/// <para><b>Half of this is a courtesy and the plan says which half.</b> The server enforces what
+/// it can see — who may share with whom, who is blocked. Export, local backup and moving an entry
+/// out of a project folder happen inside the extension, where the server has no visibility, so this
+/// document is what an honest client obeys rather than a boundary it cannot cross. Written down
+/// here because the natural mistake is to later "fix" a client-side ban by moving it to a server
+/// that cannot observe the thing it would be banning.</para>
+/// </remarks>
+public sealed record PolicyDto(bool Export, string Share, bool MoveOutOfProject);
+
+public static class MemberPolicy
+{
+    /// <summary>
+    /// The policy for a role.
+    ///
+    /// <para>An unknown role — a record written by a NEWER server than this build — takes the
+    /// developer's shape with sharing off, never the member's. Failing closed is the whole reason
+    /// the branch exists: a role this build cannot understand is one whose permissions it cannot
+    /// honestly grant.</para>
+    /// </summary>
+    public static PolicyDto For(string role, string shareDefault) => role switch
+    {
+        MemberRole.Admin or MemberRole.Member => new PolicyDto(true, ShareDefaults.Any, true),
+        MemberRole.Dev => new PolicyDto(false, NormalizeShare(shareDefault), false),
+        _ => new PolicyDto(false, ShareDefaults.None, false),
+    };
+
+    private static string NormalizeShare(string shareDefault) =>
+        ShareDefaults.IsKnown(shareDefault) ? shareDefault : ShareDefaults.None;
+}

--- a/src_minimalapi_server/src/OrgMembersStore.cs
+++ b/src_minimalapi_server/src/OrgMembersStore.cs
@@ -22,7 +22,10 @@ namespace CredVaultServer;
 /// registered".</b> The recovery store maps an unreadable file to "not there" because for a setup or a
 /// session that is the refusing direction. For a person it is the opposite: not registered means the
 /// default, the default is <c>member</c>, and a member may export — so a half-written file would have
-/// promoted a developer. The three-state result exists so that no caller can collapse it back to two.</para>
+/// promoted a developer. The three-state result exists so that no caller can collapse it back to two.
+/// "Cannot read" includes a well-formed record for the WRONG person: a record whose email does not
+/// hash to the file it sits in is refused too, or a restore that mixed two files would hand one
+/// colleague another's role.</para>
 ///
 /// <para><b>Reads are synchronous and served from memory.</b> Epic 2 puts a lookup inside the caller
 /// gate, which runs on every request and is synchronous. A cache entry carries the file's last-write
@@ -30,14 +33,16 @@ namespace CredVaultServer;
 /// editor or a second instance during a rolling restart changes the file underneath this process, and
 /// a block that a stale cache kept ignoring is the failure the whole registry is scaffolding for. A
 /// stat is microseconds. What it cannot see — a same-length rewrite inside one clock tick — no real
-/// writer produces.</para>
+/// writer produces. "No file" is cached the same way, under an empty stat, so a person who has never
+/// synced costs one thrown exception once rather than once per request.</para>
 /// </summary>
 public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log)
 {
     private readonly string _membersDir = Path.Combine(dataDir, "org", "members");
 
     // Keyed by the file key rather than the email, so a listing — which has only file names — shares
-    // the cache with the lookups.
+    // the cache with the lookups. Bounded by the number of distinct verified callers plus the number
+    // of files, which the identity provider and the roster bound between them.
     private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
 
     // Files whose I/O failure has already been logged. The gate reads on every request, so an
@@ -45,31 +50,48 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     // bounded by the number of member files, and shrinks as they recover.
     private readonly ConcurrentDictionary<string, byte> _ioFailureLogged = new();
 
+    private int _diskReads;
+
+    /// <summary>How many times the store went to the disk — a test's way of seeing the cache work.</summary>
+    internal int DiskReads => Volatile.Read(ref _diskReads);
+
     private sealed record FileStat(DateTime LastWriteUtc, long Length);
 
-    private sealed record CacheEntry(MemberLookupResult Result, FileStat Stat);
+    /// <summary>
+    /// A cached verdict under the stat that produced it. A <c>null</c> stat is a cached "no file": the
+    /// next lookup's stat is <c>null</c> too and matches, and the file appearing gives a real stat that
+    /// does not — so the negative answer is served from memory exactly until there is something to read.
+    /// </summary>
+    private sealed record CacheEntry(MemberLookupResult Result, FileStat? Stat);
 
-    private string PathFor(string key) => Path.Combine(_membersDir, key + ".json");
+    /// <summary>
+    /// One lookup's coordinates: the file key, its path, and — when a caller asked for a person rather
+    /// than listed the directory — the email they asked for, so a mismatch can name both sides.
+    /// </summary>
+    private readonly record struct Target(string Key, string FilePath, string AskedFor);
+
+    private Target TargetFor(string key, string askedFor) =>
+        new(key, Path.Combine(_membersDir, key + ".json"), askedFor);
 
     /// <summary>
     /// Three answers, never two, and never an exception — see <see cref="MemberLookup"/>.
     ///
-    /// <para>The existence check is the read itself, not <see cref="FileInfo.Exists"/>: that property
-    /// answers <c>false</c> for a directory this process may not list, and "may not read" has to come
-    /// back as <see cref="MemberLookup.Unavailable"/>, not as a person with no record. The price is one
-    /// caught <see cref="FileNotFoundException"/> per lookup of somebody who has no record — rare in corp
-    /// mode, where everyone who syncs has one — and nothing for everybody else, who is answered from the
-    /// cache after one stat.</para>
+    /// <para>The first existence check is the read itself, not <see cref="FileInfo.Exists"/>: that
+    /// property answers <c>false</c> for a directory this process may not list, and "may not read" has to
+    /// come back as <see cref="MemberLookup.Unavailable"/>, not as a person with no record. The answer is
+    /// then cached — "no file" included — so the price is one caught <see cref="FileNotFoundException"/>
+    /// per person who has no record, not one per request.</para>
     /// </summary>
-    public MemberLookupResult Find(string email) => FindByKey(VaultStore.KeyFor(email));
-
-    private MemberLookupResult FindByKey(string key)
+    public MemberLookupResult Find(string email)
     {
-        var path = PathFor(key);
-        return _cache.TryGetValue(key, out var cached) && Stat(path) == cached.Stat
-            ? cached.Result
-            : ReadFromDisk(key, path);
+        var normalized = MemberRecord.Normalize(email);
+        return FindByKey(TargetFor(VaultStore.KeyFor(normalized), normalized));
     }
+
+    private MemberLookupResult FindByKey(Target target) =>
+        _cache.TryGetValue(target.Key, out var cached) && Stat(target.FilePath) == cached.Stat
+            ? cached.Result
+            : ReadFromDisk(target);
 
     private static FileStat? Stat(string path)
     {
@@ -82,32 +104,38 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// <see cref="Find"/> re-reads; taken the other way round, a write between read and stat would be
     /// cached under the NEW stat and never seen.
     /// </summary>
-    private MemberLookupResult ReadFromDisk(string key, string path)
+    private MemberLookupResult ReadFromDisk(Target target)
     {
+        Interlocked.Increment(ref _diskReads);
         try
         {
-            var stat = Stat(path);
-            var result = Classify(File.ReadAllBytes(path), path);
-            _ioFailureLogged.TryRemove(key, out _);
-            Remember(key, stat, result);
+            var stat = Stat(target.FilePath);
+            var result = Classify(File.ReadAllBytes(target.FilePath), target);
+            _ioFailureLogged.TryRemove(target.Key, out _);
+            Remember(target.Key, stat, result);
             return result;
         }
         catch (Exception e) when (e is FileNotFoundException or DirectoryNotFoundException)
         {
-            _cache.TryRemove(key, out _);
+            // Cached under a null stat — see CacheEntry. The one thing this trusts that the first
+            // read did not is FileInfo.Exists on a file that WAS absent: a directory that later
+            // becomes unlistable keeps reading as absent for that person until a write or a restart.
+            _cache[target.Key] = new CacheEntry(MemberLookupResult.NotRegistered, null);
             return MemberLookupResult.NotRegistered;
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
             // Not cached: a lock or a permission flip may be transient, and the next read is the retry.
-            LogIoFailureOnce(key, path, e);
+            LogIoFailureOnce(target, e);
             return MemberLookupResult.Unavailable;
         }
     }
 
     /// <summary>
     /// A content verdict is cached under the stat that produced it: the same bytes give the same answer,
-    /// and a malformed record on the request path must be logged once, not once per request.
+    /// and a malformed record on the request path must be logged once, not once per request. No stat
+    /// means the file appeared between the stat and the read; nothing is cached and the next lookup
+    /// reads again.
     /// </summary>
     private void Remember(string key, FileStat? stat, MemberLookupResult result)
     {
@@ -117,51 +145,68 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
         }
     }
 
-    private void LogIoFailureOnce(string key, string path, Exception e)
+    private void LogIoFailureOnce(Target target, Exception e)
     {
-        if (_ioFailureLogged.TryAdd(key, 0))
+        if (_ioFailureLogged.TryAdd(target.Key, 0))
         {
             log.LogError(
                 e,
                 "member record {Path} cannot be opened; the person it belongs to is refused until it can be",
-                path);
+                target.FilePath);
         }
     }
 
-    private MemberLookupResult Classify(byte[] bytes, string path)
+    private MemberLookupResult Classify(byte[] bytes, Target target)
     {
         try
         {
-            return Validate(JsonSerializer.Deserialize(bytes, AppJsonContext.Default.MemberRecord), path);
+            return Validate(JsonSerializer.Deserialize(bytes, AppJsonContext.Default.MemberRecord), target);
         }
         catch (JsonException e)
         {
             log.LogError(
                 e,
                 "member record {Path} is not valid JSON; the person it belongs to is refused until it is fixed",
-                path);
+                target.FilePath);
             return MemberLookupResult.Unavailable;
         }
     }
 
-    private MemberLookupResult Validate(MemberRecord? record, string path)
+    private MemberLookupResult Validate(MemberRecord? record, Target target)
     {
         if (record is null)
         {
-            return Refuse(path, "is empty");
+            return Refuse(target.FilePath, "is empty");
         }
         if (record.SchemaVersion > MemberRecord.CurrentSchemaVersion)
         {
             // "Unknown fields I will ignore" is a promotion waiting for the field that carries a
-            // permission. A build that cannot promise it understands a record must not act on it.
+            // permission. A build that cannot promise it understands a record must not act on it —
+            // however many of the fields it does recognise.
             return Refuse(
-                path,
+                target.FilePath,
                 $"has schema version {record.SchemaVersion}; this build reads up to {MemberRecord.CurrentSchemaVersion}");
         }
         return record.IsWellFormed()
-            ? MemberLookupResult.Found(record)
-            : Refuse(path, "is missing a field or names a role or share default this build does not know");
+            ? Accept(record, target)
+            : Refuse(target.FilePath, "is missing a field or names a role or share default this build does not know");
     }
+
+    /// <summary>
+    /// The record's email must hash to the file it was found in. A restore that mixes files, or an
+    /// operator editing one by hand, otherwise puts Bob's well-formed record at Anna's key — and every
+    /// caller would apply Bob's role to Anna. Checked after <see cref="MemberRecord.IsWellFormed"/>,
+    /// which is what guarantees there is an email to hash, and before anything is cached.
+    /// </summary>
+    private MemberLookupResult Accept(MemberRecord record, Target target) =>
+        VaultStore.KeyFor(record.Email) == target.Key
+            ? MemberLookupResult.Found(record)
+            : Refuse(target.FilePath, MismatchReason(record.Email, target.AskedFor));
+
+    private static string MismatchReason(string recordEmail, string askedFor) =>
+        askedFor.Length > 0
+            ? $"names {recordEmail} but is the file for {askedFor}; refusing it rather than apply one person's record to another"
+            : $"names {recordEmail}, which does not hash to this file's name; refusing it rather than apply one person's record to another";
 
     private MemberLookupResult Refuse(string path, string reason)
     {
@@ -179,7 +224,9 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// would both read the same record, each apply their own change, and the second write would win
     /// whole. So the read, the edit and the write happen inside the lock — <see cref="VaultStore.GateFor"/>'s
     /// stripe, shared with vault writes for the same email, which is harmless and cheaper than a second
-    /// stripe with the same "everything that grows has an owner" question to answer.</para>
+    /// stripe with the same "everything that grows has an owner" question to answer. The read is inside
+    /// the lock on purpose, as <see cref="VaultStore.TryWriteVaultAsync"/>'s is: outside it, the lost
+    /// update is back.</para>
     ///
     /// <para><see cref="UpsertResult.Created"/> is reported because two callers emit
     /// <c>member.registered</c> only on a create: the sync hook, and an admin who sets a role before the
@@ -188,7 +235,7 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// <para>A record that reads as <see cref="MemberLookup.Unavailable"/> is never overwritten. The edit
     /// would have to start from the default, and a default written over a blocked developer's unreadable
     /// record is an unblock nobody ordered; <see cref="MemberRecordUnavailableException"/> names the file
-    /// instead, and the operator fixes the file.</para>
+    /// instead, the lock is released on the way out, and the operator fixes the file.</para>
     /// </summary>
     public async Task<UpsertResult> UpsertAsync(
         string email,
@@ -202,13 +249,13 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
         await gate.WaitAsync(ct);
         try
         {
-            var path = PathFor(key);
+            var target = TargetFor(key, normalized);
             var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var (baseline, created) = Baseline(ReadFromDisk(key, path), normalized, now, path);
+            var (baseline, created) = Baseline(ReadFromDisk(target), normalized, now, target.FilePath);
             var edited = Stamp(edit(baseline), normalized, byAdmin, now);
             Directory.CreateDirectory(_membersDir);
             await VaultStore.AtomicWriteAsync(
-                path,
+                target.FilePath,
                 JsonSerializer.SerializeToUtf8Bytes(edited, AppJsonContext.Default.MemberRecord),
                 ct);
             _cache.TryRemove(key, out _);
@@ -255,7 +302,8 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     }
 
     /// <summary>
-    /// Everyone in one domain, for the admin's list.
+    /// Everyone in one domain, for the admin's list. The domain may be written with or without its
+    /// <c>@</c> — doubling the sign would match nobody and answer an empty roster with no error.
     ///
     /// <para>Scoped here rather than in the endpoint so that on a server whose
     /// <c>Vault:AllowedDomains</c> names two companies, the store never hands one company's roster to
@@ -268,11 +316,11 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
         {
             return [];
         }
-        var suffix = "@" + domain.Trim().ToLowerInvariant();
+        var suffix = "@" + domain.Trim().TrimStart('@').ToLowerInvariant();
         return
         [
             .. Directory.EnumerateFiles(_membersDir, "*.json")
-                .Select(path => FindByKey(Path.GetFileNameWithoutExtension(path)))
+                .Select(path => FindByKey(TargetFor(Path.GetFileNameWithoutExtension(path), string.Empty)))
                 .SelectMany(FoundRecord)
                 .Where(record => record.Email.EndsWith(suffix, StringComparison.Ordinal)),
         ];
@@ -284,19 +332,21 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// <summary>
     /// Delete the record — <c>DELETE /api/vault</c> takes it with the vault, so the registry cannot
     /// outgrow the people it describes. Under the same gate as the writes: a delete landing between an
-    /// upsert's read and its move would be undone by the move.
+    /// upsert's read and its move would be undone by the move. Asynchronous because its caller is an
+    /// async handler, and a synchronous wait on the shared stripe would park a thread-pool thread
+    /// behind a vault write for the same stripe.
     ///
     /// <para>Best-effort like <see cref="VaultStore.DeleteEverythingFor"/>, and unlike it, it says so: a
     /// file that could not be deleted is logged rather than silently left to be listed.</para>
     /// </summary>
-    public void Remove(string email)
+    public async Task RemoveAsync(string email, CancellationToken ct)
     {
         var key = VaultStore.KeyFor(MemberRecord.Normalize(email));
         var gate = VaultStore.GateFor(key);
-        gate.Wait();
+        await gate.WaitAsync(ct);
         try
         {
-            var path = PathFor(key);
+            var path = TargetFor(key, string.Empty).FilePath;
             if (File.Exists(path))
             {
                 File.Delete(path);

--- a/src_minimalapi_server/src/OrgMembersStore.cs
+++ b/src_minimalapi_server/src/OrgMembersStore.cs
@@ -1,0 +1,329 @@
+using System.Collections.Concurrent;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace CredVaultServer;
+
+/// <summary>
+/// The members registry on disk: one small JSON record per person at
+/// <c>${DataDir}/org/members/&lt;key&gt;.json</c>, keyed exactly as vaults are
+/// (<see cref="VaultStore.KeyFor"/>) so one identity space has one hashing scheme.
+///
+/// <para>Same idioms as <see cref="OrgRecoveryStore"/> — atomic temp-then-move writes, defensive
+/// reads — with two deliberate departures from that template, both stated here so nobody later reads
+/// them as oversights:</para>
+///
+/// <para><b>Directories are created on the first write, never in the constructor.</b> The recovery
+/// store creates its tree eagerly and can afford to. This store is constructed on every deployment,
+/// personal ones included, and on a personal deployment no <c>org/</c> directory may appear at all:
+/// its presence is what tells an operator looking at the disk that this server has a roster.</para>
+///
+/// <para><b>A record this build cannot read is <see cref="MemberLookup.Unavailable"/>, never "not
+/// registered".</b> The recovery store maps an unreadable file to "not there" because for a setup or a
+/// session that is the refusing direction. For a person it is the opposite: not registered means the
+/// default, the default is <c>member</c>, and a member may export — so a half-written file would have
+/// promoted a developer. The three-state result exists so that no caller can collapse it back to two.</para>
+///
+/// <para><b>Reads are synchronous and served from memory.</b> Epic 2 puts a lookup inside the caller
+/// gate, which runs on every request and is synchronous. A cache entry carries the file's last-write
+/// time and length, and every <see cref="Find"/> re-stats before answering: a restore, an operator's
+/// editor or a second instance during a rolling restart changes the file underneath this process, and
+/// a block that a stale cache kept ignoring is the failure the whole registry is scaffolding for. A
+/// stat is microseconds. What it cannot see — a same-length rewrite inside one clock tick — no real
+/// writer produces.</para>
+/// </summary>
+public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log)
+{
+    private readonly string _membersDir = Path.Combine(dataDir, "org", "members");
+
+    // Keyed by the file key rather than the email, so a listing — which has only file names — shares
+    // the cache with the lookups.
+    private readonly ConcurrentDictionary<string, CacheEntry> _cache = new();
+
+    // Files whose I/O failure has already been logged. The gate reads on every request, so an
+    // unreadable record would otherwise log once per request. Cleared by the next successful read;
+    // bounded by the number of member files, and shrinks as they recover.
+    private readonly ConcurrentDictionary<string, byte> _ioFailureLogged = new();
+
+    private sealed record FileStat(DateTime LastWriteUtc, long Length);
+
+    private sealed record CacheEntry(MemberLookupResult Result, FileStat Stat);
+
+    private string PathFor(string key) => Path.Combine(_membersDir, key + ".json");
+
+    /// <summary>
+    /// Three answers, never two, and never an exception — see <see cref="MemberLookup"/>.
+    ///
+    /// <para>The existence check is the read itself, not <see cref="FileInfo.Exists"/>: that property
+    /// answers <c>false</c> for a directory this process may not list, and "may not read" has to come
+    /// back as <see cref="MemberLookup.Unavailable"/>, not as a person with no record. The price is one
+    /// caught <see cref="FileNotFoundException"/> per lookup of somebody who has no record — rare in corp
+    /// mode, where everyone who syncs has one — and nothing for everybody else, who is answered from the
+    /// cache after one stat.</para>
+    /// </summary>
+    public MemberLookupResult Find(string email) => FindByKey(VaultStore.KeyFor(email));
+
+    private MemberLookupResult FindByKey(string key)
+    {
+        var path = PathFor(key);
+        return _cache.TryGetValue(key, out var cached) && Stat(path) == cached.Stat
+            ? cached.Result
+            : ReadFromDisk(key, path);
+    }
+
+    private static FileStat? Stat(string path)
+    {
+        var info = new FileInfo(path);
+        return info.Exists ? new FileStat(info.LastWriteTimeUtc, info.Length) : null;
+    }
+
+    /// <summary>
+    /// Stat first, then read. A write landing between the two changes the stat, so the next
+    /// <see cref="Find"/> re-reads; taken the other way round, a write between read and stat would be
+    /// cached under the NEW stat and never seen.
+    /// </summary>
+    private MemberLookupResult ReadFromDisk(string key, string path)
+    {
+        try
+        {
+            var stat = Stat(path);
+            var result = Classify(File.ReadAllBytes(path), path);
+            _ioFailureLogged.TryRemove(key, out _);
+            Remember(key, stat, result);
+            return result;
+        }
+        catch (Exception e) when (e is FileNotFoundException or DirectoryNotFoundException)
+        {
+            _cache.TryRemove(key, out _);
+            return MemberLookupResult.NotRegistered;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Not cached: a lock or a permission flip may be transient, and the next read is the retry.
+            LogIoFailureOnce(key, path, e);
+            return MemberLookupResult.Unavailable;
+        }
+    }
+
+    /// <summary>
+    /// A content verdict is cached under the stat that produced it: the same bytes give the same answer,
+    /// and a malformed record on the request path must be logged once, not once per request.
+    /// </summary>
+    private void Remember(string key, FileStat? stat, MemberLookupResult result)
+    {
+        if (stat is not null)
+        {
+            _cache[key] = new CacheEntry(result, stat);
+        }
+    }
+
+    private void LogIoFailureOnce(string key, string path, Exception e)
+    {
+        if (_ioFailureLogged.TryAdd(key, 0))
+        {
+            log.LogError(
+                e,
+                "member record {Path} cannot be opened; the person it belongs to is refused until it can be",
+                path);
+        }
+    }
+
+    private MemberLookupResult Classify(byte[] bytes, string path)
+    {
+        try
+        {
+            return Validate(JsonSerializer.Deserialize(bytes, AppJsonContext.Default.MemberRecord), path);
+        }
+        catch (JsonException e)
+        {
+            log.LogError(
+                e,
+                "member record {Path} is not valid JSON; the person it belongs to is refused until it is fixed",
+                path);
+            return MemberLookupResult.Unavailable;
+        }
+    }
+
+    private MemberLookupResult Validate(MemberRecord? record, string path)
+    {
+        if (record is null)
+        {
+            return Refuse(path, "is empty");
+        }
+        if (record.SchemaVersion > MemberRecord.CurrentSchemaVersion)
+        {
+            // "Unknown fields I will ignore" is a promotion waiting for the field that carries a
+            // permission. A build that cannot promise it understands a record must not act on it.
+            return Refuse(
+                path,
+                $"has schema version {record.SchemaVersion}; this build reads up to {MemberRecord.CurrentSchemaVersion}");
+        }
+        return record.IsWellFormed()
+            ? MemberLookupResult.Found(record)
+            : Refuse(path, "is missing a field or names a role or share default this build does not know");
+    }
+
+    private MemberLookupResult Refuse(string path, string reason)
+    {
+        log.LogError(
+            "member record {Path} {Reason}; the person it belongs to is refused until it is fixed",
+            path,
+            reason);
+        return MemberLookupResult.Unavailable;
+    }
+
+    /// <summary>
+    /// Read-modify-write under the per-member lock, and it says whether it CREATED the record.
+    ///
+    /// <para>Atomic replacement stops a torn file, not a lost update: two admins editing one person
+    /// would both read the same record, each apply their own change, and the second write would win
+    /// whole. So the read, the edit and the write happen inside the lock — <see cref="VaultStore.GateFor"/>'s
+    /// stripe, shared with vault writes for the same email, which is harmless and cheaper than a second
+    /// stripe with the same "everything that grows has an owner" question to answer.</para>
+    ///
+    /// <para><see cref="UpsertResult.Created"/> is reported because two callers emit
+    /// <c>member.registered</c> only on a create: the sync hook, and an admin who sets a role before the
+    /// person's first sync.</para>
+    ///
+    /// <para>A record that reads as <see cref="MemberLookup.Unavailable"/> is never overwritten. The edit
+    /// would have to start from the default, and a default written over a blocked developer's unreadable
+    /// record is an unblock nobody ordered; <see cref="MemberRecordUnavailableException"/> names the file
+    /// instead, and the operator fixes the file.</para>
+    /// </summary>
+    public async Task<UpsertResult> UpsertAsync(
+        string email,
+        Func<MemberRecord, MemberRecord> edit,
+        string byAdmin,
+        CancellationToken ct)
+    {
+        var normalized = MemberRecord.Normalize(email);
+        var key = VaultStore.KeyFor(normalized);
+        var gate = VaultStore.GateFor(key);
+        await gate.WaitAsync(ct);
+        try
+        {
+            var path = PathFor(key);
+            var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var (baseline, created) = Baseline(ReadFromDisk(key, path), normalized, now, path);
+            var edited = Stamp(edit(baseline), normalized, byAdmin, now);
+            Directory.CreateDirectory(_membersDir);
+            await VaultStore.AtomicWriteAsync(
+                path,
+                JsonSerializer.SerializeToUtf8Bytes(edited, AppJsonContext.Default.MemberRecord),
+                ct);
+            _cache.TryRemove(key, out _);
+            return new UpsertResult(edited, created);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private static (MemberRecord Record, bool Created) Baseline(
+        MemberLookupResult current,
+        string email,
+        long now,
+        string path) =>
+        current switch
+        {
+            { Status: MemberLookup.Found, Record: { } record } => (record, false),
+            { Status: MemberLookup.NotRegistered } => (MemberRecord.DefaultFor(email, now), true),
+            _ => throw new MemberRecordUnavailableException(path),
+        };
+
+    /// <summary>
+    /// The key is cut from the email, so the record may not disagree with it; the stamp is the store's,
+    /// so an edit cannot forge who changed what, or when. An edit that produces a record this build
+    /// would refuse to read is a programming error and is refused before anything is written — the
+    /// alternative is a person locked out by the very call that meant to change their role.
+    /// </summary>
+    private static MemberRecord Stamp(MemberRecord edited, string email, string byAdmin, long now)
+    {
+        var stamped = edited with
+        {
+            SchemaVersion = MemberRecord.CurrentSchemaVersion,
+            Email = email,
+            UpdatedAt = now,
+            UpdatedBy = MemberRecord.Normalize(byAdmin),
+        };
+        return stamped.IsWellFormed()
+            ? stamped
+            : throw new ArgumentException(
+                "The edit produced a record this build would refuse to read; nothing was written.",
+                nameof(edited));
+    }
+
+    /// <summary>
+    /// Everyone in one domain, for the admin's list.
+    ///
+    /// <para>Scoped here rather than in the endpoint so that on a server whose
+    /// <c>Vault:AllowedDomains</c> names two companies, the store never hands one company's roster to
+    /// the other's admin. An unreadable record is absent from the list and present in the log at Error,
+    /// naming the file — and its owner meets the refusal, which is the louder of the two signals.</para>
+    /// </summary>
+    public IReadOnlyList<MemberRecord> ListForDomain(string domain)
+    {
+        if (!Directory.Exists(_membersDir))
+        {
+            return [];
+        }
+        var suffix = "@" + domain.Trim().ToLowerInvariant();
+        return
+        [
+            .. Directory.EnumerateFiles(_membersDir, "*.json")
+                .Select(path => FindByKey(Path.GetFileNameWithoutExtension(path)))
+                .SelectMany(FoundRecord)
+                .Where(record => record.Email.EndsWith(suffix, StringComparison.Ordinal)),
+        ];
+    }
+
+    private static IEnumerable<MemberRecord> FoundRecord(MemberLookupResult result) =>
+        result is { Status: MemberLookup.Found, Record: { } record } ? [record] : [];
+
+    /// <summary>
+    /// Delete the record — <c>DELETE /api/vault</c> takes it with the vault, so the registry cannot
+    /// outgrow the people it describes. Under the same gate as the writes: a delete landing between an
+    /// upsert's read and its move would be undone by the move.
+    ///
+    /// <para>Best-effort like <see cref="VaultStore.DeleteEverythingFor"/>, and unlike it, it says so: a
+    /// file that could not be deleted is logged rather than silently left to be listed.</para>
+    /// </summary>
+    public void Remove(string email)
+    {
+        var key = VaultStore.KeyFor(MemberRecord.Normalize(email));
+        var gate = VaultStore.GateFor(key);
+        gate.Wait();
+        try
+        {
+            var path = PathFor(key);
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+            _cache.TryRemove(key, out _);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            log.LogWarning(e, "member record for a deleted vault could not be removed; it stays listed until it is");
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="OrgMembersStore.UpsertAsync"/> when the record it would edit cannot be read.
+///
+/// <para>An exception rather than a fourth lookup state because it is an infrastructure failure on a
+/// write path, not an expected answer: the endpoint maps it to <c>503</c> with <c>Retry-After</c>,
+/// exactly as <c>GET /api/org/me</c> answers the same file. It is an <see cref="IOException"/> so the
+/// "catch I/O, log, try again later" idiom the maintenance passes use keeps applying to it.</para>
+/// </summary>
+public sealed class MemberRecordUnavailableException(string filePath)
+    : IOException($"The member record at '{filePath}' cannot be read by this build, so it was not overwritten.")
+{
+    public string FilePath { get; } = filePath;
+}

--- a/src_minimalapi_server/src/OrgSettingsStore.cs
+++ b/src_minimalapi_server/src/OrgSettingsStore.cs
@@ -26,12 +26,17 @@ public sealed record OrgSettingsDto(int OfflineLeaseHours, long UpdatedAt, strin
 /// deployment never grows an <c>org/</c> directory because somebody read a setting.
 ///
 /// <para>Reads never throw and are served from memory under the same stat check as the members
-/// registry. A file this build cannot read answers the DEFAULT, logged once at Error naming the file —
-/// the opposite direction from a member record, and deliberately so: nothing in this file grants a
-/// permission, so the worst a bad file can do is a lease of 24 hours where an admin wanted less, and
-/// the log says exactly that. Refusing every <c>GET /api/org/me</c> over a settings file would turn one
-/// bad file into an outage for everybody. Here <see cref="FileInfo.Exists"/> IS the existence check:
-/// the members store pays for a stricter one because "absent" there means a permission.</para>
+/// registry. <b>Absent and unreadable are different facts.</b> A file that exists but cannot be opened
+/// or parsed answers the LAST VALUE THIS PROCESS READ OR WROTE, and only a process that never had one
+/// falls back to the default — because an admin who set the lease to <c>0</c>, strictly online, must not
+/// have every client handed 24 hours back by a permission flip or a lock on the file. That is a control
+/// silently weakened by an I/O error, and the whole reason the setting exists is to be the stricter
+/// choice. Either way the log names the file at Error, once — not per call — and says which value is
+/// being answered. Refusing every <c>GET /api/org/me</c> over a settings file would turn one bad file into
+/// an outage for everybody, which is why this is not the members store's refusal.</para>
+///
+/// <para>Here <see cref="FileInfo.Exists"/> IS the existence check: the members store pays for a stricter
+/// one because "absent" there means a permission.</para>
 /// </summary>
 public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> log)
 {
@@ -42,6 +47,10 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
     private readonly SemaphoreSlim _gate = new(1, 1);
 
     private volatile CacheEntry? _cached;
+
+    // The last value this process read or wrote successfully — what an unreadable file answers.
+    private volatile OrgSettingsDto? _lastGood;
+
     private int _ioFailureLogged;
 
     private sealed record CacheEntry(OrgSettingsDto Settings, DateTime LastWriteUtc, long Length);
@@ -67,7 +76,7 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
             var settings = Parse(File.ReadAllBytes(_path));
             Interlocked.Exchange(ref _ioFailureLogged, 0);
             // The malformed verdict is cached with the stat too: the same bytes give the same answer,
-            // and an unreadable file must be logged once, not on every request.
+            // and an unparseable file must be logged once, not on every request.
             _cached = new CacheEntry(settings, info.LastWriteTimeUtc, info.Length);
             return settings;
         }
@@ -78,10 +87,17 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
+            // Not cached: a lock or a permission flip may be transient, and the next read is the retry.
             LogIoFailureOnce(e);
-            return OrgSettingsDto.Default;
+            return Fallback();
         }
     }
+
+    /// <summary>What an unreadable file answers — see the class remarks for why not the default.</summary>
+    private OrgSettingsDto Fallback() => _lastGood ?? OrgSettingsDto.Default;
+
+    private string FallbackSource() =>
+        _lastGood is null ? "the default; nothing was read before" : "the last value this process read";
 
     private OrgSettingsDto Parse(byte[] bytes)
     {
@@ -91,36 +107,42 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
             if (settings is { } read && read.IsWellFormed())
             {
                 // A hand-edited file may omit the field; the deserializer does not run the default.
-                return read with { UpdatedBy = read.UpdatedBy ?? string.Empty };
+                var good = read with { UpdatedBy = read.UpdatedBy ?? string.Empty };
+                _lastGood = good;
+                return good;
             }
-            return AnswerDefault(null, "is empty or names a negative lease");
+            return AnswerFallback(null, "is empty or names a negative lease");
         }
         catch (JsonException e)
         {
-            return AnswerDefault(e, "is not valid JSON");
+            return AnswerFallback(e, "is not valid JSON");
         }
     }
 
-    private OrgSettingsDto AnswerDefault(Exception? e, string reason)
+    private OrgSettingsDto AnswerFallback(Exception? e, string reason)
     {
+        var fallback = Fallback();
         log.LogError(
             e,
-            "org settings {Path} {Reason}; answering the default lease of {Hours} h until it is fixed",
+            "org settings {Path} {Reason}; answering a lease of {Hours} h ({Source}) until it is fixed",
             _path,
             reason,
-            OrgSettingsDto.DefaultOfflineLeaseHours);
-        return OrgSettingsDto.Default;
+            fallback.OfflineLeaseHours,
+            FallbackSource());
+        return fallback;
     }
 
     private void LogIoFailureOnce(Exception e)
     {
         if (Interlocked.Exchange(ref _ioFailureLogged, 1) == 0)
         {
+            var fallback = Fallback();
             log.LogError(
                 e,
-                "org settings {Path} cannot be opened; answering the default lease of {Hours} h until it can be",
+                "org settings {Path} cannot be opened; answering a lease of {Hours} h ({Source}) until it can be",
                 _path,
-                OrgSettingsDto.DefaultOfflineLeaseHours);
+                fallback.OfflineLeaseHours,
+                FallbackSource());
         }
     }
 
@@ -128,7 +150,8 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
     /// Read-modify-write under the one lock. Stamps who and when from the verified caller, never from
     /// the edit. A file this build cannot read is replaced by the admin's write: unlike a member record
     /// it carries nothing this build must not lose — which stops being true the day another build adds
-    /// a block to it, and the members store is the shape that carries unknowns when it does.
+    /// a block to it, and the members store is the shape that carries unknowns when it does. The value
+    /// written becomes the last good one: this process knows it, whatever the disk does next.
     /// </summary>
     public async Task<OrgSettingsDto> UpdateAsync(
         Func<OrgSettingsDto, OrgSettingsDto> edit,
@@ -145,6 +168,7 @@ public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> l
                 JsonSerializer.SerializeToUtf8Bytes(edited, AppJsonContext.Default.OrgSettingsDto),
                 ct);
             _cached = null;
+            _lastGood = edited;
             return edited;
         }
         finally

--- a/src_minimalapi_server/src/OrgSettingsStore.cs
+++ b/src_minimalapi_server/src/OrgSettingsStore.cs
@@ -1,0 +1,169 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace CredVaultServer;
+
+/// <summary>
+/// The runtime settings an admin may change without a restart — one record, and the reason it is
+/// runtime: nothing in it has a cryptographic consequence. The officer roster changes what a key is
+/// sealed to, so it is configuration plus a ceremony; the offline lease changes how long an honest
+/// client stays open, so it is one PUT away.
+/// </summary>
+public sealed record OrgSettingsDto(int OfflineLeaseHours, long UpdatedAt, string UpdatedBy)
+{
+    /// <summary>Twenty-four hours, owner decision 7. <c>0</c> is the legal "strictly online", not an error.</summary>
+    public const int DefaultOfflineLeaseHours = 24;
+
+    /// <summary>What a server with no settings file answers — computed, never written.</summary>
+    public static OrgSettingsDto Default => new(DefaultOfflineLeaseHours, 0, string.Empty);
+
+    public bool IsWellFormed() => OfflineLeaseHours >= 0;
+}
+
+/// <summary>
+/// <c>${DataDir}/org/settings.json</c>. Absent answers <see cref="OrgSettingsDto.Default"/> and writes
+/// nothing — "off is the shape, not a flag": the answer is correct before the disk agrees, and a personal
+/// deployment never grows an <c>org/</c> directory because somebody read a setting.
+///
+/// <para>Reads never throw and are served from memory under the same stat check as the members
+/// registry. A file this build cannot read answers the DEFAULT, logged once at Error naming the file —
+/// the opposite direction from a member record, and deliberately so: nothing in this file grants a
+/// permission, so the worst a bad file can do is a lease of 24 hours where an admin wanted less, and
+/// the log says exactly that. Refusing every <c>GET /api/org/me</c> over a settings file would turn one
+/// bad file into an outage for everybody. Here <see cref="FileInfo.Exists"/> IS the existence check:
+/// the members store pays for a stricter one because "absent" there means a permission.</para>
+/// </summary>
+public sealed class OrgSettingsStore(string dataDir, ILogger<OrgSettingsStore> log)
+{
+    private readonly string _orgDir = Path.Combine(dataDir, "org");
+    private readonly string _path = Path.Combine(dataDir, "org", "settings.json");
+
+    // One file, so one lock, not a stripe.
+    private readonly SemaphoreSlim _gate = new(1, 1);
+
+    private volatile CacheEntry? _cached;
+    private int _ioFailureLogged;
+
+    private sealed record CacheEntry(OrgSettingsDto Settings, DateTime LastWriteUtc, long Length);
+
+    /// <summary>The current settings; never throws.</summary>
+    public OrgSettingsDto Read()
+    {
+        var info = new FileInfo(_path);
+        if (!info.Exists)
+        {
+            return OrgSettingsDto.Default;
+        }
+        var cached = _cached;
+        return cached is not null && cached.LastWriteUtc == info.LastWriteTimeUtc && cached.Length == info.Length
+            ? cached.Settings
+            : ReadFromDisk(info);
+    }
+
+    private OrgSettingsDto ReadFromDisk(FileInfo info)
+    {
+        try
+        {
+            var settings = Parse(File.ReadAllBytes(_path));
+            Interlocked.Exchange(ref _ioFailureLogged, 0);
+            // The malformed verdict is cached with the stat too: the same bytes give the same answer,
+            // and an unreadable file must be logged once, not on every request.
+            _cached = new CacheEntry(settings, info.LastWriteTimeUtc, info.Length);
+            return settings;
+        }
+        catch (FileNotFoundException)
+        {
+            // Deleted between the stat and the read. Absent is the default, not a failure.
+            return OrgSettingsDto.Default;
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            LogIoFailureOnce(e);
+            return OrgSettingsDto.Default;
+        }
+    }
+
+    private OrgSettingsDto Parse(byte[] bytes)
+    {
+        try
+        {
+            var settings = JsonSerializer.Deserialize(bytes, AppJsonContext.Default.OrgSettingsDto);
+            if (settings is { } read && read.IsWellFormed())
+            {
+                // A hand-edited file may omit the field; the deserializer does not run the default.
+                return read with { UpdatedBy = read.UpdatedBy ?? string.Empty };
+            }
+            return AnswerDefault(null, "is empty or names a negative lease");
+        }
+        catch (JsonException e)
+        {
+            return AnswerDefault(e, "is not valid JSON");
+        }
+    }
+
+    private OrgSettingsDto AnswerDefault(Exception? e, string reason)
+    {
+        log.LogError(
+            e,
+            "org settings {Path} {Reason}; answering the default lease of {Hours} h until it is fixed",
+            _path,
+            reason,
+            OrgSettingsDto.DefaultOfflineLeaseHours);
+        return OrgSettingsDto.Default;
+    }
+
+    private void LogIoFailureOnce(Exception e)
+    {
+        if (Interlocked.Exchange(ref _ioFailureLogged, 1) == 0)
+        {
+            log.LogError(
+                e,
+                "org settings {Path} cannot be opened; answering the default lease of {Hours} h until it can be",
+                _path,
+                OrgSettingsDto.DefaultOfflineLeaseHours);
+        }
+    }
+
+    /// <summary>
+    /// Read-modify-write under the one lock. Stamps who and when from the verified caller, never from
+    /// the edit. A file this build cannot read is replaced by the admin's write: unlike a member record
+    /// it carries nothing this build must not lose — which stops being true the day another build adds
+    /// a block to it, and the members store is the shape that carries unknowns when it does.
+    /// </summary>
+    public async Task<OrgSettingsDto> UpdateAsync(
+        Func<OrgSettingsDto, OrgSettingsDto> edit,
+        string byAdmin,
+        CancellationToken ct)
+    {
+        await _gate.WaitAsync(ct);
+        try
+        {
+            var edited = Stamp(edit(Read()), byAdmin);
+            Directory.CreateDirectory(_orgDir);
+            await VaultStore.AtomicWriteAsync(
+                _path,
+                JsonSerializer.SerializeToUtf8Bytes(edited, AppJsonContext.Default.OrgSettingsDto),
+                ct);
+            _cached = null;
+            return edited;
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    private static OrgSettingsDto Stamp(OrgSettingsDto edited, string byAdmin)
+    {
+        var stamped = edited with
+        {
+            UpdatedAt = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            UpdatedBy = MemberRecord.Normalize(byAdmin),
+        };
+        return stamped.IsWellFormed()
+            ? stamped
+            : throw new ArgumentException(
+                "The edit produced a negative offline lease; nothing was written.",
+                nameof(edited));
+    }
+}

--- a/src_minimalapi_server/src/VaultStore.cs
+++ b/src_minimalapi_server/src/VaultStore.cs
@@ -112,10 +112,14 @@ public sealed partial class VaultStore
     // dictionary that grows with every account and is never pruned — the "everything that
     // grows has an owner" rule. 64 stripes means two accounts occasionally wait on each
     // other for the length of one file write, which costs nothing and cannot leak.
+    //
+    // Shared with OrgMembersStore rather than duplicated: a member upsert takes the same gate as a
+    // vault write for the same email, which is harmless — each holds it for one small file write —
+    // and one stripe is one owner to reason about instead of two.
     private static readonly SemaphoreSlim[] Gates =
         [.. Enumerable.Range(0, 64).Select(_ => new SemaphoreSlim(1, 1))];
 
-    private static SemaphoreSlim GateFor(string key) =>
+    internal static SemaphoreSlim GateFor(string key) =>
         Gates[(int)(uint.Parse(key[..8], System.Globalization.NumberStyles.HexNumber) % Gates.Length)];
 
     /// <summary>Emails of everyone with a stored vault (for team discovery).</summary>
@@ -298,7 +302,11 @@ public sealed partial class VaultStore
         return true;
     }
 
-    private static async Task AtomicWriteAsync(string path, byte[] content, CancellationToken ct)
+    /// <summary>
+    /// Temp, then move, so a reader never sees a partial file. Shared with the org stores for the
+    /// same reason the gate is: one write idiom in the server is one set of failure modes to learn.
+    /// </summary>
+    internal static async Task AtomicWriteAsync(string path, byte[] content, CancellationToken ct)
     {
         var temp = path + "." + Guid.NewGuid().ToString("N")[..8] + ".tmp";
         await File.WriteAllBytesAsync(temp, content, ct);

--- a/src_minimalapi_server/tests/CapturingLogger.cs
+++ b/src_minimalapi_server/tests/CapturingLogger.cs
@@ -1,0 +1,30 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// An <see cref="ILogger{T}"/> that keeps what was logged, for the tests whose guarantee IS a log
+/// line — "logged once per file", "logged, not thrown". A <c>NullLogger</c> proves nothing about either.
+/// </summary>
+internal sealed class CapturingLogger<T> : ILogger<T>
+{
+    private readonly ConcurrentQueue<(LogLevel Level, string Message, Exception? Exception)> _entries = new();
+
+    public IReadOnlyList<(LogLevel Level, string Message, Exception? Exception)> Entries => [.. _entries];
+
+    public IReadOnlyList<string> Errors =>
+        [.. _entries.Where(e => e.Level == LogLevel.Error).Select(e => e.Message)];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+        LogLevel logLevel,
+        EventId eventId,
+        TState state,
+        Exception? exception,
+        Func<TState, Exception?, string> formatter) =>
+        _entries.Enqueue((logLevel, formatter(state, exception), exception));
+}

--- a/src_minimalapi_server/tests/MemberPolicyTests.cs
+++ b/src_minimalapi_server/tests/MemberPolicyTests.cs
@@ -1,0 +1,70 @@
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The role → policy table. Pure, so every row is a fact the suite pins — and it needs pinning: this
+/// is the mapping every later corporate epic reads, and the client is told to trust the server's
+/// answer rather than re-derive it.
+/// </summary>
+public sealed class MemberPolicyTests
+{
+    private static readonly PolicyDto Unrestricted = new(Export: true, Share: ShareDefaults.Any, MoveOutOfProject: true);
+
+    private static readonly PolicyDto DeveloperNoSharing = new(Export: false, Share: ShareDefaults.None, MoveOutOfProject: false);
+
+    [Theory]
+    [InlineData(MemberRole.Admin, ShareDefaults.Project)]
+    [InlineData(MemberRole.Admin, ShareDefaults.None)]
+    [InlineData(MemberRole.Member, ShareDefaults.Project)]
+    [InlineData(MemberRole.Member, ShareDefaults.None)]
+    public void AnAdminOrMemberMayExportShareWithAnyoneAndMoveFreely_WhateverTheShareDefaultSays(
+        string role,
+        string shareDefault)
+    {
+        // The share default is a developer's setting. An admin may store one for a person before
+        // demoting them, and until that day it must change nothing.
+        MemberPolicy.For(role, shareDefault).Should().Be(Unrestricted);
+    }
+
+    [Fact]
+    public void ADeveloperWithTheProjectDefaultMayShareInsideAProjectAndNothingElse()
+    {
+        MemberPolicy.For(MemberRole.Dev, ShareDefaults.Project)
+            .Should().Be(new PolicyDto(Export: false, Share: ShareDefaults.Project, MoveOutOfProject: false));
+    }
+
+    [Fact]
+    public void ADeveloperWithNoSharingMayReceiveAndSendNothing()
+    {
+        MemberPolicy.For(MemberRole.Dev, ShareDefaults.None).Should().Be(DeveloperNoSharing);
+    }
+
+    [Fact]
+    public void ADeveloperWithAShareDefaultThisBuildDoesNotKnowGetsNoSharing()
+    {
+        // A value written by a newer server. Reading it as "project" would grant what this build
+        // cannot vouch for; "none" is the honest answer.
+        MemberPolicy.For(MemberRole.Dev, "everyone").Should().Be(DeveloperNoSharing);
+        MemberPolicy.For(MemberRole.Dev, string.Empty).Should().Be(DeveloperNoSharing);
+    }
+
+    [Fact]
+    public void AnUnknownRoleGetsTheMostRestrictivePolicy()
+    {
+        // A role this build cannot understand is one whose permissions it cannot honestly grant, so
+        // it takes the developer's shape with sharing off — never the member's, which would be the
+        // natural mistake and an escalation for the price of a typo in a newer server.
+        MemberPolicy.For("superuser", ShareDefaults.Project).Should().Be(DeveloperNoSharing);
+        MemberPolicy.For(string.Empty, ShareDefaults.Project).Should().Be(DeveloperNoSharing);
+    }
+
+    [Fact]
+    public void TheDefaultRoleIsMemberAndMemberIsUnrestricted()
+    {
+        // Owner decision 2: a server upgrade changes nobody's rights on its own. If this ever fails,
+        // the day a roster is configured every colleague loses export at once.
+        MemberRole.Default.Should().Be(MemberRole.Member);
+        MemberPolicy.For(MemberRole.Default, ShareDefaults.Default).Should().Be(Unrestricted);
+    }
+}

--- a/src_minimalapi_server/tests/OrgEventLogTests.cs
+++ b/src_minimalapi_server/tests/OrgEventLogTests.cs
@@ -82,7 +82,7 @@ public sealed class OrgEventLogTests : IDisposable
         _now = _now.AddMilliseconds(1);
         await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct);
 
-        Directory.EnumerateFiles(EventsDir).Select(f => Path.GetFileName(f)).Order()
+        Directory.EnumerateFiles(EventsDir, "*.ndjson").Select(f => Path.GetFileName(f)).Order()
             .Should().Equal("2026-03-01.ndjson", "2026-03-02.ndjson");
         (await File.ReadAllLinesAsync(log.PathForDay(_now), Ct)).Should().ContainSingle();
     }
@@ -152,6 +152,39 @@ public sealed class OrgEventLogTests : IDisposable
         _log.Errors.Should().ContainSingle(m => m.Contains("lock"));
         (await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct))
             .Should().BeTrue("the bound is on the wait, not on the log");
+    }
+
+    [Fact]
+    public async Task TwoInstancesOverOneDirectoryBothAppendAndEveryRowSurvives()
+    {
+        // A rolling restart has two instances writing the same day file for a while. Each holds its
+        // own in-process lock, so nothing but the file's own sharing and append semantics stands
+        // between them — and a row refused or overwritten there is a row the company never sees.
+        var first = NewLog();
+        var second = new OrgEventLog(_dir, _log, () => _now);
+        const int perInstance = 200;
+
+        var a = Task.Run(() => AppendManyAsync(first, "a", perInstance), Ct);
+        var b = Task.Run(() => AppendManyAsync(second, "b", perInstance), Ct);
+        var accepted = await Task.WhenAll(a, b);
+
+        accepted.Sum().Should().Be(2 * perInstance, "neither instance may lose a row to the other");
+        var lines = await File.ReadAllLinesAsync(first.PathForDay(Noon), Ct);
+        lines.Should().HaveCount(2 * perInstance, "every row is on its own line");
+        lines.Select(line => Parse(line).Detail).Should().OnlyHaveUniqueItems("every row is whole and parseable");
+    }
+
+    private static async Task<int> AppendManyAsync(OrgEventLog log, string tag, int count)
+    {
+        var accepted = 0;
+        for (var i = 0; i < count; i++)
+        {
+            if (await log.AppendAsync(Row(OrgEventKinds.MemberRoleChanged) with { Detail = $"{tag}{i}" }, Ct))
+            {
+                accepted++;
+            }
+        }
+        return accepted;
     }
 
     [Fact]

--- a/src_minimalapi_server/tests/OrgEventLogTests.cs
+++ b/src_minimalapi_server/tests/OrgEventLogTests.cs
@@ -1,0 +1,226 @@
+using System.Text;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The event log's writer: what the file looks like after appends, day boundaries and failures. The
+/// reader belongs to a later epic; what this one can promise is the shape of the file it leaves behind.
+/// </summary>
+public sealed class OrgEventLogTests : IDisposable
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static readonly DateTimeOffset Noon = new(2026, 3, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
+
+    private readonly CapturingLogger<OrgEventLog> _log = new();
+    private DateTimeOffset _now = Noon;
+
+    public OrgEventLogTests()
+    {
+        Directory.CreateDirectory(_dir);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A handle not yet released; the temp sweeper gets it.
+        }
+    }
+
+    private OrgEventLog NewLog(TimeSpan? lockWait = null) => new(_dir, _log, () => _now, lockWait);
+
+    private string EventsDir => Path.Combine(_dir, "org", "events");
+
+    private static OrgEventDto Row(string kind) => new(
+        At: Noon.ToUnixTimeMilliseconds(),
+        Kind: kind,
+        Actor: "admin@example.com",
+        Subject: "anna@example.com",
+        Project: null,
+        ShareId: null,
+        EntityName: null,
+        EntityKind: null,
+        Outcome: null,
+        Detail: "member -> dev");
+
+    private static OrgEventDto Parse(string line) =>
+        JsonSerializer.Deserialize(line, AppJsonContext.Default.OrgEventDto)!;
+
+    [Fact]
+    public async Task AppendThenReadTheFileBack()
+    {
+        var log = NewLog();
+
+        (await log.AppendAsync(Row(OrgEventKinds.MemberRegistered), Ct)).Should().BeTrue();
+        (await log.AppendAsync(Row(OrgEventKinds.MemberRoleChanged), Ct)).Should().BeTrue();
+
+        var lines = await File.ReadAllLinesAsync(log.PathForDay(Noon), Ct);
+        lines.Should().HaveCount(2, "one row per line, and no blank line between two whole rows");
+        Parse(lines[0]).Should().Be(Row(OrgEventKinds.MemberRegistered), "a row round-trips whole");
+        Parse(lines[1]).Kind.Should().Be(OrgEventKinds.MemberRoleChanged);
+    }
+
+    [Fact]
+    public async Task ADayBoundaryStartsANewFile()
+    {
+        // One file per UTC day is what lets a range query skip whole files. The clock is injected so
+        // midnight is a test rather than a wait.
+        var log = NewLog();
+        _now = new DateTimeOffset(2026, 3, 1, 23, 59, 59, 999, TimeSpan.Zero);
+        await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct);
+        _now = _now.AddMilliseconds(1);
+        await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct);
+
+        Directory.EnumerateFiles(EventsDir).Select(f => Path.GetFileName(f)).Order()
+            .Should().Equal("2026-03-01.ndjson", "2026-03-02.ndjson");
+        (await File.ReadAllLinesAsync(log.PathForDay(_now), Ct)).Should().ContainSingle();
+    }
+
+    [Fact]
+    public void TheDayIsTheUtcDayWhateverOffsetTheClockCarries()
+    {
+        // 01:00 at UTC+2 is still the previous day in UTC. A host that happens to run in a timezone
+        // must not split one UTC day across two files.
+        var offsetClock = new DateTimeOffset(2026, 3, 2, 1, 0, 0, TimeSpan.FromHours(2));
+
+        Path.GetFileName(NewLog().PathForDay(offsetClock)).Should().Be("2026-03-01.ndjson");
+    }
+
+    [Fact]
+    public async Task AnAppendAfterATornFinalLineStartsOnAFreshLine()
+    {
+        // A process killed mid-append leaves a partial line with no newline. Appending straight after
+        // it would fuse the torn row and the new one into one unparseable line, and the reader would
+        // lose two rows where it should lose one.
+        var log = NewLog();
+        var path = log.PathForDay(Noon);
+        await log.AppendAsync(Row(OrgEventKinds.MemberRegistered), Ct);
+        const string torn = "{\"at\":1,\"kind\":\"member.role_ch";
+        await File.AppendAllTextAsync(path, torn, Ct);
+
+        await log.AppendAsync(Row(OrgEventKinds.MemberShareDefaultChanged), Ct);
+
+        var lines = await File.ReadAllLinesAsync(path, Ct);
+        lines.Should().HaveCount(3);
+        lines[1].Should().Be(torn, "the torn line is left as it was; repairing it is the reader's decision");
+        Parse(lines[2]).Kind.Should().Be(OrgEventKinds.MemberShareDefaultChanged, "the new row is whole, on its own line");
+    }
+
+    [Fact]
+    public async Task AnUnwritableFolderIsLoggedNotThrown()
+    {
+        // The row is appended after the mutation has landed; a role change that happened must not be
+        // reported as a 500 because the log could not be written.
+        Directory.CreateDirectory(Path.Combine(_dir, "org"));
+        await File.WriteAllTextAsync(EventsDir, "a file where the folder should be", Ct);
+        var log = NewLog();
+
+        var appended = await log.AppendAsync(Row(OrgEventKinds.MemberRoleChanged), Ct);
+
+        appended.Should().BeFalse();
+        _log.Errors.Should().ContainSingle(m => m.Contains(log.PathForDay(Noon)), "the operator's signal names the file");
+    }
+
+    [Fact]
+    public async Task AStuckWriterCostsOneRowNotTheRequest()
+    {
+        // One lock for every writer: an unbounded wait here is how one stuck writer stalls the server.
+        var log = NewLog(lockWait: TimeSpan.FromMilliseconds(50));
+        await log.Gate.WaitAsync(Ct);
+        bool whileHeld;
+        try
+        {
+            whileHeld = await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct);
+        }
+        finally
+        {
+            log.Gate.Release();
+        }
+
+        whileHeld.Should().BeFalse();
+        _log.Errors.Should().ContainSingle(m => m.Contains("lock"));
+        (await log.AppendAsync(Row(OrgEventKinds.SettingsChanged), Ct))
+            .Should().BeTrue("the bound is on the wait, not on the log");
+    }
+
+    [Fact]
+    public async Task BothMaintenanceSweepsLeaveOrgEventsAlone()
+    {
+        // Kept forever, by decision. The controls matter as much as the assertion: each sweep is given
+        // something it DOES own and is shown to remove it, so "the log survived" cannot be a sweep that
+        // never ran.
+        var log = NewLog();
+        await log.AppendAsync(Row(OrgEventKinds.MemberRegistered), Ct);
+        var path = log.PathForDay(Noon);
+        File.SetLastWriteTimeUtc(path, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        var before = await File.ReadAllBytesAsync(path, Ct);
+
+        var vaults = new VaultStore(_dir);
+        var share = OldShare();
+        await vaults.AppendShareAsync(share.ToEmail, share, Ct);
+        var recovery = new OrgRecoveryStore(_dir);
+        await recovery.AppendInviteAsync(OldInvite(), Ct);
+
+        await new ShareMaintenance(
+                vaults, NullLogger<ShareMaintenance>.Instance, TimeSpan.FromHours(1), TimeSpan.FromDays(1))
+            .SweepAsync(Ct);
+        await new OrgRecoveryMaintenance(
+                recovery, NullLogger<OrgRecoveryMaintenance>.Instance, TimeSpan.FromHours(1), TimeSpan.FromHours(1))
+            .SweepAsync(Ct);
+
+        (await vaults.CountSharesAsync(share.ToEmail, Ct)).Should().Be(0, "control: the share sweep ran and pruned what it owns");
+        (await CountInvitesAsync(recovery, "lead@example.com")).Should().Be(0, "control: the invite sweep ran and dropped what it owns");
+        File.Exists(path).Should().BeTrue("the event log is nobody's to sweep");
+        (await File.ReadAllBytesAsync(path, Ct)).Should().Equal(before, "not a byte of it moved");
+    }
+
+    private static ShareItem OldShare() => new()
+    {
+        Id = Guid.NewGuid().ToString(),
+        FromEmail = "alice@example.com",
+        ToEmail = "bob@example.com",
+        EntityName = "old thing",
+        EntityKind = "db",
+        CreatedAt = DateTimeOffset.UtcNow.AddDays(-40).ToUnixTimeMilliseconds(),
+        Salt = Convert.ToBase64String(new byte[16]),
+        Iv = Convert.ToBase64String(new byte[12]),
+        Tag = Convert.ToBase64String(new byte[16]),
+        Data = Convert.ToBase64String(Encoding.UTF8.GetBytes("sealed")),
+    };
+
+    private static EscrowInviteItem OldInvite() => new()
+    {
+        SetupId = Guid.NewGuid().ToString(),
+        FromEmail = "cto@example.com",
+        ToEmail = "lead@example.com",
+        ShareIndex = 1,
+        Threshold = 2,
+        TotalShares = 3,
+        CreatedAt = DateTimeOffset.UtcNow.AddHours(-100).ToUnixTimeMilliseconds(),
+        Salt = Convert.ToBase64String(new byte[16]),
+        Iv = Convert.ToBase64String(new byte[12]),
+        Tag = Convert.ToBase64String(new byte[16]),
+        Data = Convert.ToBase64String(new byte[48]),
+    };
+
+    private static async Task<int> CountInvitesAsync(OrgRecoveryStore store, string email)
+    {
+        var seen = 0;
+        await foreach (var _ in store.ListInvitesAsync(email, Ct))
+        {
+            seen++;
+        }
+        return seen;
+    }
+}

--- a/src_minimalapi_server/tests/OrgMembersStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgMembersStoreTests.cs
@@ -204,6 +204,66 @@ public sealed class OrgMembersStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task AHigherSchemaVersionIsUnavailableEvenWhenEveryFieldIsOneThisBuildKnows()
+    {
+        // The version is the contract, not the fields. A record above this build's version is refused
+        // whole — never read "as far as this build understands it", and never rewritten at the older
+        // version by the next edit, which would silently downgrade what the newer build meant.
+        var fromTheFuture = MemberRecord.DefaultFor(Anna, 1) with
+        {
+            SchemaVersion = MemberRecord.CurrentSchemaVersion + 1,
+            Role = MemberRole.Dev,
+        };
+        WriteRecord(Anna, fromTheFuture);
+        var bytes = await File.ReadAllBytesAsync(RecordPath(Anna), Ct);
+
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Unavailable, "every field is known; the version alone refuses it");
+        var act = () => _store.UpsertAsync(Anna, r => r with { Role = MemberRole.Admin }, Admin, Ct);
+        await act.Should().ThrowAsync<MemberRecordUnavailableException>("it is not merged into this build's shape");
+        (await File.ReadAllBytesAsync(RecordPath(Anna), Ct)).Should().Equal(bytes, "and not a byte of it was rewritten");
+    }
+
+    [Fact]
+    public void ARecordWhoseEmailDoesNotMatchItsFilenameIsUnavailable()
+    {
+        // A restore that mixes files, or an operator editing one by hand: a well-formed record for
+        // Bob sitting at Anna's key would otherwise be Found, and Anna would be given Bob's role.
+        WriteRecord(Anna, MemberRecord.DefaultFor("bob@example.com", 1) with { Role = MemberRole.Admin });
+
+        var lookup = _store.Find(Anna);
+
+        lookup.Status.Should().Be(MemberLookup.Unavailable, "one person's record must never be applied to another");
+        _log.Errors.Should().ContainSingle(
+            m => m.Contains(RecordPath(Anna)) && m.Contains("bob@example.com") && m.Contains(Anna),
+            "the operator needs the file and both emails to untangle it");
+    }
+
+    [Fact]
+    public void AnUnregisteredLookupIsAnsweredFromTheCacheOnTheSecondCall()
+    {
+        // The gate will ask on every request. Somebody with no record — a token that has never
+        // synced — must not cost a thrown FileNotFoundException per request.
+        _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
+        _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
+
+        _store.DiskReads.Should().Be(1, "the second answer came from memory");
+    }
+
+    [Fact]
+    public void ARecordCreatedAfterAnUnregisteredLookupIsSeenOnTheNextFind()
+    {
+        // The negative answer is cached; the file appearing — a sync on another instance, a restore —
+        // must invalidate it, or a registered person would stay unregistered until a restart.
+        _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
+        WriteRecord(Anna, MemberRecord.DefaultFor(Anna, 1) with { Role = MemberRole.Dev });
+
+        var found = _store.Find(Anna);
+
+        found.Status.Should().Be(MemberLookup.Found);
+        found.Record!.Role.Should().Be(MemberRole.Dev);
+    }
+
+    [Fact]
     public async Task AnUnknownFieldRoundTripsByteForByte()
     {
         // A NEWER build added a field without bumping the version — the additive case. This build
@@ -257,13 +317,13 @@ public sealed class OrgMembersStoreTests : IDisposable
     // ---------------------------------------------------------------- the rest of the surface
 
     [Fact]
-    public void NothingCreatesTheOrgDirectoryUntilAWrite()
+    public async Task NothingCreatesTheOrgDirectoryUntilAWrite()
     {
         // This store is constructed on every deployment, personal ones included. An org/ directory
         // on a personal server would tell an operator it has a roster it does not have.
         _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
         _store.ListForDomain("example.com").Should().BeEmpty();
-        _store.Remove(Anna);
+        await _store.RemoveAsync(Anna, Ct);
 
         Directory.Exists(Path.Combine(_dir, "org")).Should().BeFalse("reads and a no-op remove leave the disk as they found it");
     }
@@ -302,6 +362,16 @@ public sealed class OrgMembersStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ListForDomainAcceptsADomainWrittenWithItsAtSign()
+    {
+        // "@example.com" is how a domain is often typed. Doubling the sign would match nobody and
+        // answer an empty roster with no error — the silent kind of wrong.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+
+        _store.ListForDomain("@example.com").Select(r => r.Email).Should().Equal(Anna);
+    }
+
+    [Fact]
     public async Task RemoveTakesTheRecordAndTheNextFindIsNotRegistered()
     {
         // DELETE /api/vault takes the record with the vault, so the registry cannot outgrow the
@@ -309,7 +379,7 @@ public sealed class OrgMembersStoreTests : IDisposable
         await _store.UpsertAsync(Anna, r => r, Admin, Ct);
         _store.Find(Anna).Status.Should().Be(MemberLookup.Found);
 
-        _store.Remove(Anna);
+        await _store.RemoveAsync(Anna, Ct);
 
         _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
         File.Exists(RecordPath(Anna)).Should().BeFalse();

--- a/src_minimalapi_server/tests/OrgMembersStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgMembersStoreTests.cs
@@ -1,0 +1,317 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The members registry — the data-format and concurrency contract every later corporate epic reads.
+///
+/// <para>Driven against the store directly on a throwaway data directory, no host: what is under test
+/// is what a file on disk MEANS, and the finding the plan round opened with — a record this build
+/// cannot read is a refusal, never the member default.</para>
+///
+/// <para>Two tests rewrite a record in place with the SAME length and either keep or bump its mtime.
+/// That is the weakest trace a real writer leaves, and it separates "answered from memory" from "saw
+/// the change" without a test hook in the store.</para>
+/// </summary>
+public sealed class OrgMembersStoreTests : IDisposable
+{
+    private const string Anna = "anna@example.com";
+    private const string Admin = "admin@example.com";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
+
+    private readonly CapturingLogger<OrgMembersStore> _log = new();
+    private readonly OrgMembersStore _store;
+
+    public OrgMembersStoreTests()
+    {
+        Directory.CreateDirectory(_dir);
+        _store = new OrgMembersStore(_dir, _log);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A handle not yet released; the temp sweeper gets it.
+        }
+    }
+
+    private string MembersDir => Path.Combine(_dir, "org", "members");
+
+    /// <summary>The documented layout. The first test that writes asserts the store agrees with it.</summary>
+    private string RecordPath(string email) => Path.Combine(MembersDir, VaultStore.KeyFor(email) + ".json");
+
+    private void WriteRaw(string email, string text)
+    {
+        Directory.CreateDirectory(MembersDir);
+        var path = RecordPath(email);
+        File.WriteAllText(path, text);
+        Touch(path);
+    }
+
+    private void WriteRecord(string email, MemberRecord record) =>
+        WriteRaw(email, JsonSerializer.Serialize(record, AppJsonContext.Default.MemberRecord));
+
+    /// <summary>
+    /// Two writes inside one clock tick can share an mtime, so every out-of-process write here moves it
+    /// forward explicitly — as the seconds between a restore and the next request would.
+    /// </summary>
+    private static void Touch(string path) =>
+        File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+
+    /// <summary>Rewrite the record so that only the mtime could betray the change.</summary>
+    private static void RewriteSameLength(
+        string path,
+        MemberRecord current,
+        Func<MemberRecord, MemberRecord> change,
+        bool keepMtime)
+    {
+        var mtime = File.GetLastWriteTimeUtc(path);
+        var length = new FileInfo(path).Length;
+        File.WriteAllBytes(path, JsonSerializer.SerializeToUtf8Bytes(change(current), AppJsonContext.Default.MemberRecord));
+        new FileInfo(path).Length.Should().Be(length, "the change must be invisible through the length");
+        File.SetLastWriteTimeUtc(path, keepMtime ? mtime : mtime.AddSeconds(2));
+    }
+
+    // ---------------------------------------------------------------- the cache
+
+    [Fact]
+    public async Task FindAnswersFromTheCacheAfterOneRead()
+    {
+        // The caller gate will call Find on every request (epic 2); a disk read per request is the
+        // wrong shape. A same-length rewrite that keeps the mtime is invisible to the stat check, so
+        // a second Find that still answers the OLD bytes can only have come from memory.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        var path = RecordPath(Anna);
+        File.Exists(path).Should().BeTrue("the layout is DataDir/org/members/KeyFor(email).json");
+        var first = _store.Find(Anna);
+        first.Status.Should().Be(MemberLookup.Found);
+
+        RewriteSameLength(path, first.Record!, r => r with { LoginKeyVersion = 7 }, keepMtime: true);
+
+        _store.Find(Anna).Record!.LoginKeyVersion.Should().Be(0, "the second answer came from memory, not the disk");
+    }
+
+    [Fact]
+    public async Task AWriteThroughTheStoreInvalidatesTheCache()
+    {
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        _store.Find(Anna).Record!.Role.Should().Be(MemberRole.Member);
+
+        await _store.UpsertAsync(Anna, r => r with { Role = MemberRole.Admin }, Admin, Ct);
+
+        _store.Find(Anna).Record!.Role.Should().Be(MemberRole.Admin);
+    }
+
+    [Fact]
+    public async Task AnAlreadyCachedRecordChangedOnDiskByAnotherWriterIsReRead()
+    {
+        // A restore, an operator's editor, a second instance in a rolling restart: none of them go
+        // through this process, and epic 2's block check would keep admitting somebody blocked minutes
+        // ago. The STAT check — not a cache miss — is what notices. Same-length rewrite again, so the
+        // mtime is the only signal, which is the least a real write leaves behind.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        var cached = _store.Find(Anna).Record!;
+
+        RewriteSameLength(RecordPath(Anna), cached, r => r with { LoginKeyVersion = 7 }, keepMtime: false);
+
+        _store.Find(Anna).Record!.LoginKeyVersion.Should().Be(7, "the file changed under the cache and the stat check saw it");
+    }
+
+    // ---------------------------------------------------------------- the lock
+
+    [Fact]
+    public async Task TwoConcurrentUpsertsEditingDifferentFieldsBothSurvive()
+    {
+        // Atomic replacement stops a torn file, not a lost update. The sleep inside each edit widens
+        // the read-modify-write window so that WITHOUT the lock both would read the same baseline and
+        // the second write would win whole — the defect the per-member lock exists to prevent.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+
+        var promote = Task.Run(
+            () => _store.UpsertAsync(
+                Anna,
+                r =>
+                {
+                    Thread.Sleep(150);
+                    return r with { Role = MemberRole.Admin };
+                },
+                Admin,
+                Ct),
+            Ct);
+        var restrict = Task.Run(
+            () => _store.UpsertAsync(
+                Anna,
+                r =>
+                {
+                    Thread.Sleep(150);
+                    return r with { ShareDefault = ShareDefaults.None };
+                },
+                Admin,
+                Ct),
+            Ct);
+        await Task.WhenAll(promote, restrict);
+
+        var record = _store.Find(Anna).Record!;
+        record.Role.Should().Be(MemberRole.Admin);
+        record.ShareDefault.Should().Be(ShareDefaults.None);
+    }
+
+    // ------------------------------------------------- unreadable is a refusal, never a default
+
+    [Fact]
+    public void AMalformedRecordIsUnavailableNeverNotRegistered()
+    {
+        // The finding the plan round opened with. "Not registered" means the default, the default is
+        // member, and a member may export: a half-written file would promote a developer. Unavailable
+        // is a refusal a person can see and an operator can fix.
+        WriteRaw(Anna, "{ not json");
+
+        var first = _store.Find(Anna);
+        var second = _store.Find(Anna);
+
+        first.Status.Should().Be(MemberLookup.Unavailable, "never NotRegistered — that is the escalation");
+        second.Status.Should().Be(MemberLookup.Unavailable);
+        _log.Errors.Should().ContainSingle(
+            m => m.Contains(RecordPath(Anna)),
+            "once per file, not once per request, and naming the file");
+    }
+
+    [Fact]
+    public void AHigherSchemaVersionIsUnavailable()
+    {
+        // A build that cannot promise it understands a record must not act on it — "unknown fields I
+        // will ignore" is a promotion waiting for the field that carries a permission.
+        var fromTheFuture = MemberRecord.DefaultFor(Anna, 1) with { SchemaVersion = MemberRecord.CurrentSchemaVersion + 1 };
+        WriteRecord(Anna, fromTheFuture);
+
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Unavailable);
+        _log.Errors.Should().ContainSingle(m => m.Contains("schema version"));
+
+        // The control: the same record at this build's version is a fixture the code accepts, so the
+        // refusal above was about the version and nothing else.
+        WriteRecord(Anna, fromTheFuture with { SchemaVersion = MemberRecord.CurrentSchemaVersion });
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Found);
+    }
+
+    [Fact]
+    public async Task AnUnknownFieldRoundTripsByteForByte()
+    {
+        // A NEWER build added a field without bumping the version — the additive case. This build
+        // reads the record, an admin changes the role, and the write-back must carry what it did not
+        // understand: System.Text.Json drops unknown properties in silence, and nothing would notice.
+        var known = JsonSerializer.Serialize(MemberRecord.DefaultFor(Anna, 1), AppJsonContext.Default.MemberRecord);
+        const string future = "\"futureField\":{\"a\":1.5,\"b\":\"x\",\"c\":[true,null]}";
+        WriteRaw(Anna, known[..^1] + "," + future + "}");
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Found, "an additive field is not a refusal");
+
+        await _store.UpsertAsync(Anna, r => r with { Role = MemberRole.Dev }, Admin, Ct);
+
+        var written = await File.ReadAllTextAsync(RecordPath(Anna), Ct);
+        written.Should().Contain(future, "the field this build does not know came back exactly as it went in");
+        _store.Find(Anna).Record!.Role.Should().Be(MemberRole.Dev, "and the edit itself landed");
+    }
+
+    [Fact]
+    public async Task AReadThatCannotOpenTheFileIsUnavailableAndDoesNotPropagate()
+    {
+        // The gate calls Find on every request; an exception there is a stack trace where a sentence
+        // belongs. Another process holding the file exclusively is the ordinary way a read fails.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        MemberLookupResult whileLocked;
+        using (new FileStream(RecordPath(Anna), FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            whileLocked = _store.Find(Anna);
+        }
+
+        whileLocked.Status.Should().Be(MemberLookup.Unavailable);
+        _log.Errors.Should().ContainSingle(m => m.Contains(RecordPath(Anna)));
+        _store.Find(Anna).Status.Should().Be(
+            MemberLookup.Found,
+            "an I/O failure may be transient and is not cached; the next read is the retry");
+    }
+
+    [Fact]
+    public async Task AnUpsertAgainstAnUnavailableRecordRefusesRatherThanOverwriting()
+    {
+        // The edit would start from the default, and a default written over a blocked developer's
+        // unreadable record is an unblock nobody ordered.
+        WriteRaw(Anna, "{ not json");
+
+        var act = () => _store.UpsertAsync(Anna, r => r with { Role = MemberRole.Admin }, Admin, Ct);
+
+        await act.Should().ThrowAsync<MemberRecordUnavailableException>();
+        (await File.ReadAllTextAsync(RecordPath(Anna), Ct))
+            .Should().Be("{ not json", "the file is left for the operator, never replaced by a default");
+    }
+
+    // ---------------------------------------------------------------- the rest of the surface
+
+    [Fact]
+    public void NothingCreatesTheOrgDirectoryUntilAWrite()
+    {
+        // This store is constructed on every deployment, personal ones included. An org/ directory
+        // on a personal server would tell an operator it has a roster it does not have.
+        _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
+        _store.ListForDomain("example.com").Should().BeEmpty();
+        _store.Remove(Anna);
+
+        Directory.Exists(Path.Combine(_dir, "org")).Should().BeFalse("reads and a no-op remove leave the disk as they found it");
+    }
+
+    [Fact]
+    public async Task UpsertReportsCreatedOnceAndStampsTheRecordItself()
+    {
+        var first = await _store.UpsertAsync(" Anna@Example.COM ", r => r, Anna, Ct);
+        var second = await _store.UpsertAsync(
+            Anna,
+            r => r with { Role = MemberRole.Dev, Email = "someone-else@example.com", UpdatedBy = "forged@example.com" },
+            Admin,
+            Ct);
+
+        first.Created.Should().BeTrue("the sync hook emits member.registered on exactly this answer");
+        second.Created.Should().BeFalse();
+        second.Record.Email.Should().Be(Anna, "the key is cut from the email, so the record may not disagree with it");
+        second.Record.UpdatedBy.Should().Be(Admin, "who changed it comes from the caller, never from the edit");
+        second.Record.SchemaVersion.Should().Be(MemberRecord.CurrentSchemaVersion);
+        second.Record.UpdatedAt.Should().BeGreaterThanOrEqualTo(first.Record.UpdatedAt);
+        Directory.Exists(MembersDir).Should().BeTrue("the first write is what creates the directory");
+    }
+
+    [Fact]
+    public async Task ListForDomainAnswersOnlyThatDomain()
+    {
+        // On a server whose Vault:AllowedDomains names two companies, one company's admin must not
+        // see the other's roster.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        await _store.UpsertAsync("boris@other.example", r => r, Admin, Ct);
+
+        _store.ListForDomain("example.com").Select(r => r.Email).Should().Equal(Anna);
+        _store.ListForDomain(" EXAMPLE.COM ").Select(r => r.Email)
+            .Should().Equal(new[] { Anna }, "domains compare case-insensitively, as DomainOf does");
+        _store.ListForDomain("nobody.example").Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveTakesTheRecordAndTheNextFindIsNotRegistered()
+    {
+        // DELETE /api/vault takes the record with the vault, so the registry cannot outgrow the
+        // people it describes.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Found);
+
+        _store.Remove(Anna);
+
+        _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
+        File.Exists(RecordPath(Anna)).Should().BeFalse();
+    }
+}

--- a/src_minimalapi_server/tests/OrgSettingsStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgSettingsStoreTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The runtime settings: one file, absent by default, and what a bad one means.
+/// </summary>
+public sealed class OrgSettingsStoreTests : IDisposable
+{
+    private const string Admin = "admin@example.com";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private readonly string _dir =
+        Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
+
+    private readonly CapturingLogger<OrgSettingsStore> _log = new();
+    private readonly OrgSettingsStore _store;
+
+    public OrgSettingsStoreTests()
+    {
+        Directory.CreateDirectory(_dir);
+        _store = new OrgSettingsStore(_dir, _log);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_dir, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A handle not yet released; the temp sweeper gets it.
+        }
+    }
+
+    private string OrgDir => Path.Combine(_dir, "org");
+
+    private string SettingsPath => Path.Combine(OrgDir, "settings.json");
+
+    [Fact]
+    public void AbsentFileAnswersTheDefaultAndWritesNothing()
+    {
+        // "Off is the shape, not a flag": the answer is correct before the disk agrees, and a read on
+        // a personal deployment must not grow an org/ directory.
+        var settings = _store.Read();
+
+        settings.Should().Be(OrgSettingsDto.Default);
+        settings.OfflineLeaseHours.Should().Be(24, "owner decision 7");
+        Directory.Exists(OrgDir).Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task WriteThenRead()
+    {
+        var written = await _store.UpdateAsync(s => s with { OfflineLeaseHours = 0 }, Admin, Ct);
+
+        written.OfflineLeaseHours.Should().Be(0, "zero is the legal strictly-online, not an error");
+        written.UpdatedBy.Should().Be(Admin, "who changed it comes from the caller, never from the edit");
+        written.UpdatedAt.Should().BePositive();
+        File.Exists(SettingsPath).Should().BeTrue("the layout is DataDir/org/settings.json");
+        _store.Read().Should().Be(written);
+    }
+
+    [Fact]
+    public void AMalformedFileAnswersTheDefaultAndSaysSoOnce()
+    {
+        // Nothing in this file grants a permission, so the failing direction is the default lease,
+        // said out loud: refusing every GET /api/org/me over a settings file would be an outage.
+        Directory.CreateDirectory(OrgDir);
+        File.WriteAllText(SettingsPath, "{ nope");
+
+        _store.Read().Should().Be(OrgSettingsDto.Default);
+        _store.Read().Should().Be(OrgSettingsDto.Default);
+
+        _log.Errors.Should().ContainSingle(m => m.Contains(SettingsPath), "once per file, naming it");
+    }
+
+    [Fact]
+    public async Task AChangeMadeOutsideTheProcessIsSeenOnTheNextRead()
+    {
+        // Same stat check as the members registry: a restore or a second instance changes the file
+        // underneath this one.
+        await _store.UpdateAsync(s => s with { OfflineLeaseHours = 8 }, Admin, Ct);
+        _store.Read().OfflineLeaseHours.Should().Be(8);
+
+        File.WriteAllBytes(
+            SettingsPath,
+            JsonSerializer.SerializeToUtf8Bytes(new OrgSettingsDto(3, 1, "ops@example.com"), AppJsonContext.Default.OrgSettingsDto));
+        File.SetLastWriteTimeUtc(SettingsPath, File.GetLastWriteTimeUtc(SettingsPath).AddSeconds(2));
+
+        _store.Read().OfflineLeaseHours.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task ANegativeLeaseIsRefusedBeforeAnythingIsWritten()
+    {
+        var act = () => _store.UpdateAsync(s => s with { OfflineLeaseHours = -1 }, Admin, Ct);
+
+        await act.Should().ThrowAsync<ArgumentException>();
+        Directory.Exists(OrgDir).Should().BeFalse("a refused edit leaves the disk as it found it");
+    }
+}

--- a/src_minimalapi_server/tests/OrgSettingsStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgSettingsStoreTests.cs
@@ -94,6 +94,66 @@ public sealed class OrgSettingsStoreTests : IDisposable
         _store.Read().OfflineLeaseHours.Should().Be(3);
     }
 
+    /// <summary>Two writes inside one clock tick can share an mtime; an outside write moves it forward explicitly.</summary>
+    private static void Touch(string path) =>
+        File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+
+    [Fact]
+    public async Task AFileThatCanNoLongerBeOpenedAnswersTheLastValueThisProcessRead()
+    {
+        // An admin set strictly-online. A lock or a permission flip on the file must not hand every
+        // client 24 hours back — that is a control silently weakened by an I/O error.
+        await _store.UpdateAsync(s => s with { OfflineLeaseHours = 0 }, Admin, Ct);
+        _store.Read().OfflineLeaseHours.Should().Be(0);
+        Touch(SettingsPath); // so the cache cannot answer, and the store has to go to the disk
+
+        int whileLocked;
+        int stillLocked;
+        using (new FileStream(SettingsPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            whileLocked = _store.Read().OfflineLeaseHours;
+            stillLocked = _store.Read().OfflineLeaseHours;
+        }
+
+        whileLocked.Should().Be(0, "the last value this process read, not the default");
+        stillLocked.Should().Be(0);
+        _log.Errors.Should().ContainSingle(m => m.Contains(SettingsPath), "once per failure, not per call");
+    }
+
+    [Fact]
+    public async Task AFileThatCanNoLongerBeParsedAnswersTheLastValueThisProcessRead()
+    {
+        await _store.UpdateAsync(s => s with { OfflineLeaseHours = 0 }, Admin, Ct);
+        _store.Read().OfflineLeaseHours.Should().Be(0);
+        await File.WriteAllTextAsync(SettingsPath, "{ half-written", Ct);
+        Touch(SettingsPath);
+
+        _store.Read().OfflineLeaseHours.Should().Be(0, "the last value this process read, not the default");
+        _store.Read().OfflineLeaseHours.Should().Be(0);
+        _log.Errors.Should().ContainSingle(m => m.Contains(SettingsPath), "once per file, not per call");
+    }
+
+    [Fact]
+    public async Task AFileThatCannotBeOpenedWithNothingReadBeforeAnswersTheDefault()
+    {
+        // The other direction: a process that has never read a value has nothing better than the
+        // default to offer, and says so.
+        Directory.CreateDirectory(OrgDir);
+        await File.WriteAllBytesAsync(
+            SettingsPath,
+            JsonSerializer.SerializeToUtf8Bytes(new OrgSettingsDto(0, 1, Admin), AppJsonContext.Default.OrgSettingsDto),
+            Ct);
+
+        int whileLocked;
+        using (new FileStream(SettingsPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None))
+        {
+            whileLocked = _store.Read().OfflineLeaseHours;
+        }
+
+        whileLocked.Should().Be(OrgSettingsDto.DefaultOfflineLeaseHours);
+        _log.Errors.Should().ContainSingle(m => m.Contains(SettingsPath));
+    }
+
     [Fact]
     public async Task ANegativeLeaseIsRefusedBeforeAnythingIsWritten()
     {

--- a/todo/PLAN_corp_blocking_login_key.md
+++ b/todo/PLAN_corp_blocking_login_key.md
@@ -84,6 +84,12 @@ for the two places that must not consult the registry. **Epic 1 must expose a sy
 `Find(email)` over an in-memory cache** — see *Contract with epic 1* below — or every one of the
 ~17 call sites becomes async for a disk read on the hot path.
 
+**`Unavailable` refuses too, with `503`.** `RequireActiveCaller` has three branches, not two: a
+record that says `active: false` is `403` with the reason header below, and a record this build
+could not read is `503` with `Retry-After` — never served as though the person were active. Failing
+open here would mean one corrupted file re-admits somebody a company has just locked out, which is
+the one outcome this epic exists to prevent.
+
 **The refusal carries `X-Creds-Reason: account-deactivated`.** A client that must lock the account
 and purge local key material cannot be asked to match on English prose, and a 403 for a disallowed
 domain must stay distinguishable from a 403 for a blocked person.
@@ -178,9 +184,17 @@ leave four open doors, three of them in the panel header. Every handler carries 
 Epic 2 needs, and epic 1 must ship:
 
 ```csharp
-Member? Find(string email);   // synchronous, from an in-memory cache; null = not registered
-Task SetActiveAsync(string email, bool active, string byAdmin, CancellationToken ct);
+// Three answers, not two. Epic 1's round found that a null for "could not read it" is a
+// privilege escalation, and the same null here would be a worse one: a record this build
+// cannot read must not read as an ACTIVE person.
+MemberLookupResult Find(string email);   // synchronous, from an in-memory cache, never throws
+Task<UpsertResult> UpsertAsync(string email, Func<MemberRecord, MemberRecord> edit,
+                               string byAdmin, CancellationToken ct);
 ```
+
+**Blocking is `UpsertAsync(email, r => r with { Active = false }, admin, ct)`** — not a second
+method and not a second write path, because the per-member lock that stops two admins losing each
+other's edit lives inside that one call.
 
 The cache is loaded lazily per email and invalidated on write — the registry is small (200 records
 of about a kilobyte) and read on every request, so a disk read per call is the wrong shape. If epic 1

--- a/todo/PLAN_corp_event_log.md
+++ b/todo/PLAN_corp_event_log.md
@@ -123,7 +123,7 @@ public sealed record OrgEventQuery(string? Actor, string? Subject, string? Perso
 | Group | Kinds |
 |---|---|
 | shares | `share.sent`, `share.accepted`, `share.declined`, `share.unknown`, `share.withdrawn`, `share.withdrawn_blocked`, `share.expired` |
-| people | `member.role_changed`, `member.share_default_changed`, `member.blocked`, `member.unblocked` |
+| people | `member.registered`, `member.role_changed`, `member.share_default_changed`, `member.blocked`, `member.unblocked` |
 | projects | `project.created`, `project.renamed`, `project.archived`, `project.assigned`, `project.unassigned` |
 | keys | `loginkey.issued`, `loginkey.revoked` |
 | operations | `settings.changed`, `backup.configured`, `backup.run`, `backup.failed` |

--- a/todo/PLAN_corp_registry_roles.md
+++ b/todo/PLAN_corp_registry_roles.md
@@ -294,6 +294,18 @@ cannot:
    an unbounded wait on a request path is how one stuck writer becomes a stalled server. The wait is
    bounded at five seconds; past it the append is abandoned under rule 1.
 
+   **The lock has a second half, and a measurement is why.** A semaphore orders writers inside one
+   process; a rolling restart has two processes writing the same day file. The code round proposed
+   `FileMode.Append` for an OS-atomic write, and that was measured and refuted: .NET's `Append` is
+   `OpenOrCreate` plus a seek to the end **at open time**, not `O_APPEND`, so two writers who open at
+   the same length write at the same offset. Four hundred rows from two instances came back as 329,
+   344, 336, 334, 347, 296 and 314 across seven runs — **with every append reporting success**. So a
+   `.append.lock` beside the day file, opened `FileShare.None`, held across one probe and one write,
+   retried every 5 ms under the same five-second deadline; eight of eight repeats then complete.
+   Worth knowing for the same reason: the earlier `FileShare.Read` would have refused the second
+   process on Windows and, on Linux, where .NET maps it to an advisory shared lock, would have let it
+   clobber silently.
+
 Every mutation above gets an **end-to-end test** that performs the request and reads the log back,
 because the failure this prevents is exactly a green suite over a silent log.
 
@@ -358,6 +370,7 @@ Each of these was under-specified enough that two people would have implemented 
 | Surface | Size at 200 people | Retired by | Interrupted |
 |---|---|---|---|
 | `org/members/*.json` | ~200 KB | deleted with the vault (`DELETE /api/vault` gains the registry file); otherwise kept — a person leaves by being blocked | atomic write, nothing partial |
+| *(the listing's own budget)* | the admin list reads every record in the domain, served from the same stat-checked cache | **above roughly 2,000 members** that read stops being free and the endpoint needs pagination — a code-round finding, rejected for this shape and recorded here as the threshold rather than built now | — |
 | `org/settings.json` | one record | overwritten | atomic write |
 | `org/events/*.ndjson` | ~50 KB/day, **kept forever**, ~18 MB/year — decision 11 | nobody; the sweeps must skip it, pinned by a test | a torn final line is skipped by the reader (epic 4) and logged once |
 

--- a/todo/PLAN_corp_registry_roles.md
+++ b/todo/PLAN_corp_registry_roles.md
@@ -141,9 +141,19 @@ async turns roughly seventeen call sites into awaits for a file that is at most 
 records. So the store exposes:
 
 ```csharp
-MemberRecord? Find(string email);      // synchronous, from the cache; null = not registered
-Task<MemberRecord> UpsertAsync(string email, Func<MemberRecord, MemberRecord> edit, string byAdmin, CancellationToken ct);
+// Three answers, never two — a null here is what the escalation above was made of.
+MemberLookupResult Find(string email);          // synchronous, from the cache, never throws
+Task<UpsertResult> UpsertAsync(string email, Func<MemberRecord, MemberRecord> edit,
+                               string byAdmin, CancellationToken ct);   // says whether it CREATED
+IReadOnlyList<MemberRecord> ListForDomain(string domain);
+void Remove(string email);                       // DELETE /api/vault takes the record with it
 ```
+
+`UpsertResult` reports `Created` because two callers need to know: the registration hook emits
+`member.registered` only on a create, and an admin upsert that creates a record emits it too, with
+the admin as the actor. **Epic 2's `SetActiveAsync` is this same `UpsertAsync`**
+(`r => r with { Active = false }`), not a second write path around the lock; epic 2's plan is
+corrected to say so.
 
 The cache is filled lazily per email and invalidated by every write that goes through the store, so
 there is exactly one path that mutates it — and that is not enough on its own, which two findings
@@ -240,7 +250,7 @@ serializer; a missing entry fails at runtime, and the file's own header says so.
 | File | New/modify | Responsibility |
 |---|---|---|
 | `src/OrgMembers.cs` | new | The records above, `MemberRole`/`ShareDefault` validation, `PolicyFor(role, shareDefault)` as a pure function. |
-| `src/OrgMembersStore.cs` | new | `${DataDir}/org/members/<KeyFor(email)>.json`. `EnsureRegisteredAsync`, `ReadAsync`, `WriteAsync`, `ListForDomainAsync`. Structurally identical to `OrgRecoveryStore.cs` — its header (`OrgRecoveryStore.cs:10-12`) states why a second storage style is a second set of failure modes. Atomic write per `OrgRecoveryStore.cs:374-379`; keys from `VaultStore.KeyFor` (`VaultStore.cs:30-36`) so one identity space has one hashing scheme. A record that will not parse is treated as *not registered*, logged once, never fatal. |
+| `src/OrgMembersStore.cs` | new | `${DataDir}/org/members/<KeyFor(email)>.json`, with the four methods named above. Same idioms as `OrgRecoveryStore.cs` — atomic write per `OrgRecoveryStore.cs:374-379`, keys from `VaultStore.KeyFor` (`VaultStore.cs:30-36`) so one identity space has one hashing scheme — with **two deliberate departures from that template, both stated in the file header**: its directories are created lazily on the first write, not in the constructor (`OrgRecoveryStore.cs:29-40` creates eagerly, and this store is constructed on every deployment including personal ones, where no `org/` may appear); and a record that will not parse is **`Unavailable`, never *not registered*** — the difference is the escalation this plan's round found. The per-member lock reuses `VaultStore`'s stripe by widening `GateFor` (`VaultStore.cs:115-119`) from `private static` to `internal static`, rather than standing up a second one; a member upsert and a vault write for the same email then share a gate, which is harmless and worth saying out loud. |
 | `src/OrgSettingsStore.cs` | new | `${DataDir}/org/settings.json`, one record. Absent → the endpoint answers the default and writes nothing. |
 | `src/OrgEventLog.cs` | new | Append-only NDJSON at `${DataDir}/org/events/<yyyy-MM-dd>.ndjson`, `AppendAsync(OrgEventDto)` under **one dedicated `SemaphoreSlim(1,1)`** — every writer appends to the same file, so the vault's 64-way stripe does not apply and a comment says why, or somebody will "optimise" it into a race. The row shape and the kinds are defined in [PLAN_corp_event_log.md](PLAN_corp_event_log.md); the reader is that epic's. The break-glass audit log's bare `File.AppendAllTextAsync` (`OrgRecoveryStore.cs:312-317`) is safe only because a recovery is rare — it is the precedent for the *format*, not for the locking. Its own root, never under `org-recovery/`, so no future sweep can reach it. |
 | `src/OrgEndpoints.cs` | new | `MapOrgEndpoints(...)`, an extension method holding this epic's five routes. **`Program.cs` is 1,381 lines today** and the five epics add about twenty endpoints between them, against the coding-style ceiling of 800. So the corporate surface is registered from per-epic files starting with the first one, the way the logic and storage halves are already split into `Org*.cs` / `Org*Store.cs`. |
@@ -313,6 +323,36 @@ belongs in the release notes.
 | `package.json` | modify | `credSshManager.setMemberRole` beside `createForUser` (`:637`, menu `:1393`), gated `viewItem == teamMember-adminView`; `credSshManager.showMyRole` beside `showOrgRecovery` (`:803`, menu `:1588`), reusing the existing `viewItem =~ /^account-corp/` guard, which already means "corp mode is on for this account". |
 | `src/contractVersion.ts` | modify | `CLIENT_CONTRACT_VERSION = 3` (`:19`), with an `ORG_POLICY_CONTRACT = 3` documented in the style of `SHARE_FORMAT_CONTRACT`. |
 
+## The small decisions the story split had to ask about
+
+Each of these was under-specified enough that two people would have implemented it two ways.
+
+- **`member.registered` has two emitters**, not one: the sync hook, and an admin upsert that creates
+  a record before the person has ever synced. The actor differs (the person, then the admin); the
+  kind does not. It is added to epic 4's kinds union, where it was missing.
+- **`SetMemberRequest` with both fields null is `400`**, not a no-op that answers `200` and changes
+  nothing. A `shareDefault` sent for a non-developer is **stored**, not refused: it only takes
+  effect for `dev`, exactly as `MemberPolicy.For` reads it, and refusing it would stop an admin
+  setting the shape before demoting somebody.
+- **The gate writes the JSON body itself.** `RequireOfficer` sets a status and writes nothing
+  (`Program.cs:696-708`), so a `RequireAdmin` modelled on it would produce an empty `403` where this
+  plan promised an `ErrorDto`. A `FailJson` sibling of `Fail` (`Program.cs:465-469`) is what the
+  gate and the endpoints both call.
+- **`Retry-After` on the `503` is one named constant** in `OrgEndpoints.cs`, not a number typed at
+  each site.
+- **`MapOrgEndpoints` takes one `OrgEndpointDeps` record** — the gates, `DomainOf`, `orgRecovery`,
+  the three stores, `allowAnyDomain`, the logger. They are local functions in a top-level
+  `Program.cs` and cross the file boundary only as delegates; a record lets epics 2–5 widen the
+  dependency set without editing the call site each time.
+- **The appender guarantees the shape of the file, not the reader's tolerance of it.** Epic 4 owns
+  the reader and its torn-line skip. What this epic can promise is that an append after a torn final
+  line starts on a fresh one — it checks the last byte and prefixes `\n` — because otherwise the
+  torn row and the next one fuse, and epic 4's skip loses two rows where it should lose one.
+- **The client trusts the server's `policy` and uses `role` only for the UI.** The server derives
+  the policy (§The shapes); a client that re-derived it would be a second implementation of the same
+  rule, drifting the day either changes. An unknown role therefore means "show no admin actions",
+  and the most-restrictive fallback applies only when `policy` itself is absent or malformed.
+
 ## Growth
 
 | Surface | Size at 200 people | Retired by | Interrupted |
@@ -325,17 +365,26 @@ belongs in the release notes.
 
 Server first; the extension cannot be tested against an endpoint that does not exist.
 
-1. `OrgMembers.cs` + `OrgMembersStore.cs` + `AppJsonContext` entries; store-level tests.
+1. `OrgMembers.cs` + `OrgMembersStore.cs` + **`OrgSettingsStore.cs`** + `AppJsonContext` entries;
+   store-level tests. The settings store moves up from step 5: `MemberSelfDto.OfflineLeaseHours`
+   comes out of it, so `GET /api/org/me` cannot be built before it exists — the original order had
+   the endpoint preceding its own data source.
 2. `OrgEventLog.cs` + its append test, plus the test proving `ShareMaintenance` and
    `OrgRecoveryMaintenance` do not touch `org/events/`.
-3. `RequireAdmin`; the registration hook at `Program.cs:628`; `GET /api/org/me` including the
-   no-write default.
-4. `GET /api/org/members`, `PUT /api/org/members/{email}` with the officer `409` and upsert.
-5. `OrgSettingsStore.cs` + both settings endpoints.
+3. The registration hook at `Program.cs:628`; `GET /api/org/me` including the no-write default;
+   **`DELETE /api/vault` removes the registry record** (named only in §Growth before this, and a
+   growth budget nothing implements is a budget nobody keeps).
+4. `RequireAdmin` — moved down to sit with its first caller. A gate with no caller is exactly the
+   "control that exists in source and is never called" this repository has shipped before.
+5. `GET /api/org/members`, `PUT /api/org/members/{email}`, and both settings endpoints.
 6. `/api/team` corp-mode filter: inactive members dropped. The DTO keeps its single field until
    epic 3 widens it.
-7. `ContractVersion.Current = 3` + the corp floor + the reason text.
-8. `http/org/*.http` written and run green.
+7. `ContractVersion.Current = 3` + the corp floor + the reason text, **and the client constant in
+   the same story** (`contractVersion.ts:19`) — the two are one cutover, and splitting them opens a
+   window in which this repository's own extension is refused by its own server.
+8. `http/org/*.http` written and run green — **and `http/httpyac.config.js:43` bumped from
+   `contract: '2'` to `'3'`**, which nothing else in this plan mentioned: the suite runs against a
+   corp-mode server, so without it every request in the whole tree answers `426`.
 9. Extension: `contractVersion.ts`, `orgMembersClient.ts`, `corpPolicy.ts` + tests.
 10. Extension: `refreshOrgPolicy` wiring, the cache, the contextValues, and a **wiring test** in the
     shape of `orgRecoveryWiring.test.ts` — this repository has already shipped a corp feature whose
@@ -402,6 +451,19 @@ Server first; the extension cannot be tested against an endpoint that does not e
    alternative promotes a developer by corrupting a file — but one bad file locks one person out
    until an operator looks. Taken deliberately: it is loud, it names the file, and it costs one
    record rather than the service.
+
+## How this epic is built: four stories
+
+Split by Fable after the plan round, and regrouped rather than sliced along the build order — the
+regrouping is what the numbered steps above now reflect. Each story is reviewed on its own diff,
+tested, documented and committed before the next one starts.
+
+| # | Story | Risk |
+|---|---|---|
+| 1 | The server can persist who its people are, and never mistakes a record it cannot read for one it can — the three stores, the three-state lookup, the schema version, the per-member lock | expensive to get wrong: the data-format and concurrency contract every later epic reads |
+| 2 | On a corp server everyone who syncs is registered, every client can read its role and policy, and a client too old to read it is refused — the hook, `GET /api/org/me`, the team filter, the contract cutover on both halves | expensive: a fail-closed `503` on the request path and a hard version cutover |
+| 3 | An admin can see the roster, set a role and a share default, and change the offline lease, and every change leaves a row — `RequireAdmin` and the four admin routes | expensive: this is the authorization surface, and both the cross-domain hole and the officer-demotion lie were real findings |
+| 4 | The extension knows each account's role, shows it, and lets an admin set one from the Team row | ordinary: every rule is a pure module with a unit test, and the server is the boundary |
 
 ## The plan round (2026-09-04)
 

--- a/todo/PLAN_corp_registry_roles.md
+++ b/todo/PLAN_corp_registry_roles.md
@@ -47,6 +47,25 @@ Out of scope, by decision: blocking and the login key (epic 2 owns `active`'s *b
 only reserves the field), projects (epic 3 owns `projects[]`'s *behaviour*; this epic reserves the
 field and the DTO shape), the log's query surface (epic 4), backup (epic 5).
 
+## What this epic is NOT — the finding the round opened with
+
+**Contract 3 and the policy document are not an enforcement boundary, and this plan has to say so
+where somebody reading only this plan will see it.** A developer holding a valid token can call
+`POST /api/shares` or `GET /api/vault` with `curl`; nothing in this epic stops them, because
+everything this epic ships is a document the client is expected to obey. The umbrella's *Boundaries*
+table grades every rule, and the three this epic publishes fall out like this:
+
+| Rule | Enforced where | Lands in |
+|---|---|---|
+| a developer may not export, back up locally, clone into a personal account | the shipped extension only — a mistake, not an insider | epic 2 |
+| a developer may share only inside a project, with an active member of it | **the server**, at `POST /api/shares` | **epic 3** |
+| a blocked person may do nothing at all | **the server**, in the caller gate | **epic 2** |
+
+So the contract floor exists for a narrower reason than "make the policy binding": a client below 3
+cannot even READ the policy, and one that cannot read it cannot be expected to obey any of it.
+Serving it would be serving a bypass *and* hiding that from whoever deployed the server. That is
+worth a `426`; it is not worth calling security.
+
 ## Decisions taken here, with their reasons
 
 **Corp mode is `orgRecovery.Enabled`, not a new key.** `OrgRecoveryConfig.Read` already computes it
@@ -61,6 +80,13 @@ registry write is its sibling, idempotent, and gated on corp mode so a personal 
 creates the directory at all. Registering on every authenticated call would fill an admin's list
 with tokens that synced nothing.
 
+**And the hook may never fail the write it rides on.** By the time it runs, `TryWriteVaultAsync` has
+already succeeded, so a registry write that throws — disk full, a lock, a permission — is caught,
+logged at `Error`, and swallowed: answering `500` for a vault that was in fact stored is a worse
+failure than an unregistered person, and an unregistered person is a state this design already
+handles, because `GET /api/org/me` computes the default and the next sync retries the same
+idempotent write.
+
 **`GET /api/org/me` never writes.** A caller whose token is valid but who has never synced gets a
 *computed* default — `member`, active, no projects — with no file created. This is
 `OrgRecoveryConfig.Read`'s "off is the shape, not a flag" discipline applied to a person: the answer
@@ -73,9 +99,40 @@ join the DTO in epic 3**, which is the epic that touches `Models.cs` and needs t
 its own filtering — one epic owns one field, or two plans describe the same change and neither
 builds it.
 
+**A role may be set only for somebody in the caller's own domain.** Two reviewers found this
+independently and it was a real hole: the plan scoped the LIST by `DomainOf` and said nothing about
+the upsert, so on a server whose `Vault:AllowedDomains` names two companies, an admin at one could
+write a role for a person at the other. `PUT /api/org/members/{email}` refuses a cross-domain target
+with `403`, exactly as the break-glass session start already does (`Program.cs:983` —
+`!allowAnyDomain && DomainOf(target) != DomainOf(caller)`), and the refusal has its own test.
+`Vault:AllowAnyDomain` keeps its meaning: a deployment that deliberately turned domain scoping off
+gets none here either.
+
 **An officer's email cannot be given a role.** `PUT /api/org/members/{email}` naming an officer
 answers `409`, never a silent no-op — the roster is config, changing it needs a ceremony
 (`PLAN_org_recovery.md` §Top risks 1), and a UI that appeared to demote an officer would be lying.
+
+**A record this build cannot read is not a person without rights — and it is not a person with
+DEFAULT rights either.** This plan said an unparseable record "is treated as *not registered*", and
+the round is what showed that sentence to be a privilege escalation wearing a defensive coat: not
+registered means the default, the default is `member`, and a member may export. Corrupt one file —
+a half-written record, a bad sector, a restore from a truncated archive — and a developer becomes a
+member. So the lookup has three answers, not two:
+
+```csharp
+public enum MemberLookup { Found, NotRegistered, Unavailable }
+```
+
+- **`NotRegistered`** — no file. The person has never synced, so the computed default applies; that
+  is the whole reason `GET /api/org/me` can answer before the disk agrees.
+- **`Unavailable`** — a file exists and this build could not read it: malformed JSON, an I/O error,
+  a schema version it refuses. Every caller fails CLOSED — `RequireAdmin` refuses, `GET /api/org/me`
+  answers **`503`** with `Retry-After`, and the reason is logged at `Error` naming the file. A
+  refusal a person can see and an operator can fix beats a silent promotion nobody can.
+- **A read on the request path may never throw.** The gate calls `Find` on every request; an
+  exception there answers a stack trace where a sentence belongs. The store catches `IOException`,
+  `UnauthorizedAccessException` and `JsonException`, answers `Unavailable`, and logs once per file
+  rather than once per request.
 
 **The registry is read synchronously, from an in-memory cache.** Epic 2 puts an `active` check
 inside the caller gate, which runs on every request and is synchronous today
@@ -89,8 +146,23 @@ Task<MemberRecord> UpsertAsync(string email, Func<MemberRecord, MemberRecord> ed
 ```
 
 The cache is filled lazily per email and invalidated by every write that goes through the store, so
-there is exactly one path that mutates it. This is a contract epics 2, 3 and 4 build on; changing it
-later changes them.
+there is exactly one path that mutates it — and that is not enough on its own, which two findings
+caught between them:
+
+- **A cached record goes stale the moment anything outside this process writes the file** — a
+  restore, an operator's editor, a second instance during a rolling restart. Left alone, epic 2's
+  block check would keep admitting somebody blocked minutes ago, which is the one thing it exists to
+  prevent. So a cache entry carries the file's `LastWriteTimeUtc` and length and `Find` re-stats
+  before answering; a mismatch re-reads. A stat is microseconds; a stale block is the failure this
+  whole epic is scaffolding for. **The test is an ALREADY-CACHED record changed on disk by another
+  writer** — not the cache miss this plan originally tested, which proved nothing about it.
+- **Two admins editing one person can lose an edit.** Atomic replacement stops a torn file, not a
+  lost update: both calls read the same record, each applies its own change, and the second write
+  wins whole. `UpsertAsync` does its read-modify-write **inside a per-member lock**, the striped
+  semaphore `VaultStore` already uses for this exact reason (`VaultStore.cs:115-119`, and the
+  TOCTOU note above it). Tested with two concurrent edits to two different fields, both surviving.
+
+This is a contract epics 2, 3 and 4 build on; changing it later changes them.
 
 **Runtime settings are runtime because they have no cryptographic consequence.** `offlineLeaseHours`
 changes behaviour; the officer roster changes what a key is sealed to. The first is one PUT away,
@@ -142,6 +214,22 @@ moveOutOfProject: true}`. Derived, because a stored copy of a rule is a second s
 drifts from the role it was derived from — the failure `module_extension.md` records as "the kind is
 carried, not re-derived" in reverse.
 
+**A record from a NEWER build must round-trip through this one.** `System.Text.Json` drops an
+unknown property in silence, so an older server reading a record a newer one wrote and then writing
+it back — which every role change does — would strip whatever the newer build added, and nothing
+would notice. This is the extension's own hard-won rule in a second setting: *a wrap this build
+cannot use is one it must carry* (`module_extension.md`, §Cryptography). So `MemberRecord` carries:
+
+```csharp
+int SchemaVersion,                                                        // 1 today
+[property: JsonExtensionData] IDictionary<string, JsonElement>? Unknown   // carried, never dropped
+```
+
+A record whose `SchemaVersion` exceeds this build's is `Unavailable`, not "unknown fields I will
+ignore": a build that cannot promise it understands a record must not act on it. The test writes a
+record with an extra field and a bumped version, reads it, writes it back, and asserts the extra
+field survives byte for byte.
+
 **Every DTO gets a `[JsonSerializable]` line in `AppJsonContext.cs:33-59`.** AOT has no reflection
 serializer; a missing entry fails at runtime, and the file's own header says so.
 
@@ -171,6 +259,34 @@ serializer; a missing entry fails at runtime, and the file's own header says so.
 | GET | `/api/org/settings` | `RequireAdmin` | `/api/org-recovery/config` read half | `OrgSettingsDto`; absent file → default 24. |
 | PUT | `/api/org/settings` | `RequireAdmin` | same, write half | `offlineLeaseHours >= 0`; `0` is the legal "strictly online", not an error. |
 
+### The event log — what emits, and what a failure means
+
+The round's sharpest reliability finding was that this epic ships a log nothing is required to write
+to: every endpoint here could pass its tests over an empty file. So the emissions are part of the
+plan rather than of somebody's memory.
+
+| Event | Emitted by | Carries |
+|---|---|---|
+| `member.registered` | the registration hook (`Program.cs:628`), on the write that creates a record | subject, the default role |
+| `member.role_changed` | `PUT /api/org/members/{email}` when the role differs | actor, subject, from → to |
+| `member.share_default_changed` | the same endpoint when the share default differs | actor, subject, from → to |
+| `settings.changed` | `PUT /api/org/settings` | actor, the field, from → to |
+
+Two rules about failure, because "append-only" says nothing about what happens when the append
+cannot:
+
+1. **The row is appended AFTER the mutation has landed, and a failed append never fails the
+   mutation.** A role change that happened must not be reported as a `500`; the write is already on
+   disk, and a client that retried would be acting on a lie. The failure is logged at `Error` naming
+   the file — the operator's signal that the log has stopped recording.
+2. **The append waits for its lock with a bound.** One `SemaphoreSlim(1, 1)` is the right shape —
+   there is exactly one file per day, so a "per-file lock" is the same lock under another name — but
+   an unbounded wait on a request path is how one stuck writer becomes a stalled server. The wait is
+   bounded at five seconds; past it the append is abandoned under rule 1.
+
+Every mutation above gets an **end-to-end test** that performs the request and reads the log back,
+because the failure this prevents is exactly a green suite over a silent log.
+
 ### Contract 3 and the corp floor
 
 `ContractVersion.Current` becomes 3 (`ContractVersion.cs:40`). `Vault:MinimumClientContract` stays
@@ -189,7 +305,7 @@ belongs in the release notes.
 |---|---|---|
 | `src/corpApiClient.ts` | new | The request plumbing every corporate client needs — `url()`, `headersFor()`, `request()`, the contract header, the timeout — extracted from `orgRecoveryClient.ts`, which becomes its first caller with no change in behaviour. **Extracted here, not later**: epics 2 and 5 each add a client, so by epic 2 there would be three copies of it and by epic 5 four. The reuse-first rule's answer to that is to pull the common half out before the second copy exists. |
 | `src/orgMembersClient.ts` | new | `readMe`, `listMembers`, `setMember`, `readSettings`, `writeSettings`, on top of `corpApiClient`. Separate from `ServerTransport` for the reason `orgRecoveryClient.ts:10-14` gives: `VaultTransport` is implemented by a folder and a git remote too, and widening it with corp methods makes them carry a concept they cannot mean. |
-| `src/corpPolicy.ts` | new, pure | `corpPolicy(facts)` → `{role, policy, leaseHours, fetchedAt}` and `accountContextValue` extension. Pure so the rule is a unit test, exactly as `orgRecoveryAccess.ts:38-64` is. |
+| `src/corpPolicy.ts` | new, pure | `corpPolicy(facts)` → `{role, policy, leaseHours, fetchedAt}` and `accountContextValue` extension. Pure so the rule is a unit test, exactly as `orgRecoveryAccess.ts:38-64` is. **The admin predicate is `role === 'admin' \|\| isOfficer`, never the role alone** — the round caught this backwards: the server's `RequireAdmin` admits an officer unconditionally, and an officer cannot be given a registry role (that is the `409`), so gating the UI on the role would show an officer no management actions while the server served every one of them. `MemberSelfDto` already carries `IsOfficer` for it. |
 | `src/orgRecoveryAccess.ts` | modify | The union gains `admin` and `dev`; `accountContextValue` (`:53-64`) gains `account-corpAdmin` and `account-corpDev`. Officer stays highest — an officer is always an admin, so no combined state exists. The prefix rule (`viewItem =~ /^account-corp/`) keeps working for everything already contributed against it. |
 | `src/extension.ts` | modify | `refreshOrgPolicy(account)` beside `refreshOrgAccess` (`:459-479`), called from the same per-account loop (`:481-489`). One fetch per readiness cycle. A failure caches the previous answer and never throws — the org-escrow rule "not knowing changes nothing" applies here too. **The success timestamp is the offline lease's heartbeat** (epic 2 reads it). |
 | `src/treeDataProvider.ts` | modify | `orgPolicy` cache beside `orgAccess` (`:91`); the `teamMember` row (`:455-466`) shows the role in its description and takes `teamMember-adminView` when the viewing account is an admin, so the QuickPick does not appear for a member looking at colleagues. |
@@ -231,17 +347,27 @@ Server first; the extension cannot be tested against an endpoint that does not e
 
 **Server** (`tests/`, xUnit v3 on MTP, `VaultServer` + `Tokens.For`, `[Collection(ServerCollection.Name)]`):
 
-- `OrgMembersStoreTests`: `Find` answers from the cache after one read; a write invalidates it; a
-  record written by another process is picked up on the next miss.
+- `OrgMembersStoreTests`: `Find` answers from the cache after one read; a write invalidates it;
+  **an ALREADY-CACHED record changed on disk by another writer is re-read on the next `Find`** (the
+  stat check, not a cache miss); two concurrent `UpsertAsync` calls editing different fields both
+  survive; a malformed record answers `Unavailable`, never `NotRegistered`; a record with a higher
+  `SchemaVersion` answers `Unavailable`; an unknown field round-trips byte for byte; a read that
+  throws `IOException` answers `Unavailable` and does not propagate.
 - `OrgMembersTests`: registration happens on the first `PUT /api/vault` and not on `GET /api/org/me`;
   default role is `member`; a second PUT does not rewrite the record; personal mode creates no
   `org/` directory at all.
 - `OrgAdminGateTests`: an officer with no registry row passes `RequireAdmin`; a registry admin
   passes; a member gets `403`; corp mode off gets the same `403`, indistinguishable.
-- `OrgMembersAdminTests`: list is domain-scoped; upsert for a never-synced email; officer → `409`;
-  invalid role → `400`; `UpdatedBy` comes from the token even when the body claims otherwise.
+- `OrgMembersAdminTests`: list is domain-scoped; upsert for a never-synced email; **a cross-domain
+  target → `403`**; officer → `409`; invalid role → `400`; `UpdatedBy` comes from the token even
+  when the body claims otherwise; a role change and a share-default change each leave exactly one
+  event-log row.
+- `OrgUnavailableTests`: with a corrupted record on disk, `GET /api/org/me` answers `503` and
+  `RequireAdmin` refuses — never the member default, which is the escalation the round found.
+- `OrgRegistrationTests`: a registry write that fails does not fail the vault write, and the next
+  write registers the person after all.
 - `OrgSettingsTests`: default without a file; PUT then GET; `0` accepted; negative `400`;
-  non-admin `403`.
+  non-admin `403`; a change leaves exactly one `settings.changed` row.
 - `TeamCorpTests`: an inactive member is absent in corp mode and present in personal mode; the
   response shape is unchanged for an old client.
 - `ContractVersionTests` (extend): corp mode floors the minimum at 3 even with the configured
@@ -253,7 +379,8 @@ Server first; the extension cannot be tested against an endpoint that does not e
 
 - `corpPolicy.test.ts`: role → policy table, including the two dev share defaults; a failed fetch
   keeps the previous answer; an unknown role from a newer server degrades to the most restrictive
-  policy rather than the most permissive.
+  policy rather than the most permissive; **an officer whose role is `member` still gets the admin
+  view**.
 - `orgRecoveryAccess.test.ts` (extend): the two new contextValues, and that `account` is still
   byte-identical when corp mode is off.
 - `orgMembersClient.test.ts`: response shape guards, contract header sent, `426` surfaced as the
@@ -271,6 +398,29 @@ Server first; the extension cannot be tested against an endpoint that does not e
    it needs a release note, not a mitigation.
 4. **An unknown role from a newer server** must fail closed. Written as a test above because the
    opposite is the natural mistake.
+5. **`503` on an unreadable record is a refusal a person meets.** Fail-closed is right — the
+   alternative promotes a developer by corrupting a file — but one bad file locks one person out
+   until an operator looks. Taken deliberately: it is loud, it names the file, and it costs one
+   record rather than the service.
+
+## The plan round (2026-09-04)
+
+Three reviewers, three vendors, all three answered; fourteen findings, twelve gating; verdict
+`good_enough`, the stage's round budget being one.
+
+**Twelve accepted and folded in above**: the export ban graded honestly rather than implied by the
+contract floor; cross-domain role writes refused; the event log given its emissions and its failure
+semantics; the cache made to notice an external write; lost updates closed with a per-member lock;
+officers admitted to the admin view; the log's lock bounded; a three-state lookup so an unreadable
+record can never read as the member default; a schema version with unknown fields carried; and the
+registration hook made unable to fail a vault write that had already landed.
+
+**Two rejected as duplicates** of findings already accepted — a second statement of the stale-cache
+defect and a second of the schema-version one — with the reason recorded in the gate: one change
+described twice is how the two descriptions later disagree.
+
+The most valuable finding was one this plan created itself. *"An unparseable record is treated as not
+registered"* read as defensive, and was an escalation whose trigger is a corrupted file.
 
 ## Definition of Done
 


### PR DESCRIPTION
## What changed, and why

The six plans of the corporate control plane are already on `main` (#17). This branch is what
happened to them next, and the first code:

- **Epic 1's plan, after two review rounds.** The plan round found twelve things worth changing, and
  the most valuable was a hole the plan had written itself: *"an unparseable member record is treated
  as not registered"* reads as defensive and is a privilege escalation, because not registered means
  the computed default, the default is `member`, and a member may export. Corrupt one file and a
  developer becomes a member. Then the story split found that the same escalation had survived in two
  more places — including epic 2's blocking gate, which would have failed **open**: one corrupt file
  re-admitting somebody a company had just locked out.
- **Epic 1, story 1: three stores and no HTTP.** Nothing on the wire changes; what exists now is the
  place the next three stories write into.

The lookup has three answers rather than two. `NotRegistered` means no file, so the computed default
applies — that is how somebody who has never synced is answered before the disk agrees. `Unavailable`
means a file exists and this build could not read it, and every caller fails closed.

Three more properties, each with the failure it prevents: every lookup re-stats the file before
trusting the cache, so a record changed by a restore or a second instance is seen on the next call —
epic 2's block check is built on that; an upsert reads, edits and writes inside the vault's own
per-email lock, so two admins editing one person cannot lose an edit; and a field this build does not
know is carried and written back, because serializers drop unknown properties in silence and an older
instance would otherwise strip what a newer one wrote.

## Evidence

- [x] **Red-green:** every behavioural fix was watched failing first, with the real symptom. The
      mismatched-email record came back `Found` where `Unavailable` was expected; the second lookup of
      an unregistered person read the disk twice; the locked settings file answered `24` where `0`
      had been set; and the two-instance event-log append lost 61 of 400 rows. The concurrency and
      cache guarantees were also proven by removing them: without the per-member lock the two
      concurrent upserts collide, and without the stat comparison the cache serves the stale value.
- [x] **All the tests ran:**

```
dotnet build dew_flow_creds_for_devs.slnx -c Debug
  Build succeeded. 0 Warning(s) 0 Error(s)

./src_minimalapi_server/tests/bin/Debug/net10.0/CredVaultServer.Tests.exe
  total: 207   failed: 0   succeeded: 207   skipped: 0   duration: 13s 427ms     (164 before this branch)

node .claude/rules/shared/tools/plan-lifecycle.mjs   →  clean.
node .claude/rules/shared/tools/pin-check.mjs        →  OK — 1 pin(s) at their remote tips.
```

**One measurement worth reading.** The code round proposed `FileMode.Append` to make the event log's
append atomic across processes. It was measured and refuted: .NET's `Append` is `OpenOrCreate` plus a
seek to the end **at open time**, not `O_APPEND`, so two writers who open at the same length write at
the same offset. Four hundred rows from two instances came back as 329, 344, 336, 334, 347, 296 and
314 across seven runs — with every append reporting success. The fix is a lock file held across one
probe and one write under the same five-second deadline; eight of eight repeats then complete. Both
the plan and the module doc record the refuted version, because it is the one a reader would reach
for.

## Documentation

- [x] `research/module_server.md`: the four new files, the three `org/` paths, and what is true about
      each of them — the email-key check, the negative cache, the last-good settings value, the
      two-half lock. It describes only what this story ships; there are no endpoints yet.
- [x] `todo/README.md` indexes the six plans; the plan-lifecycle check enforces that the index and
      the folder agree.
- [ ] No plan is finished yet, so nothing is promoted out of `todo/`.
- [ ] No route changed: the `.http` suite and `POST_DEPLOY.md` are untouched. Story 2 brings the
      first endpoint and bumps the suite's own contract pin, which no plan had noticed.

## The reviewer

Both gates ran, and both are folded in.

- **Plan round** (epic 1): three vendors, all three answered, fourteen findings, twelve gating.
  Twelve accepted, two rejected as duplicates of accepted ones. The most valuable was the escalation
  above, which the plan had written itself.
- **Code round** (story 1's diff): nine reviewers, eighteen findings, fifteen gating. Ten accepted
  and fixed in `bc3b709`; eight rejected with reasons — three are refuted by the code itself
  (`KeyFor` normalizes internally; `Stamp` overwrites the email the key is cut from; the
  extension-data property is already a body property), two describe a mechanism that does not exist
  (a file held by another process fails a read immediately rather than blocking it), two would
  reintroduce the lost update this story exists to close, and one sizes the registry at fifty times
  the volume the plan budgets — with the threshold at which it becomes right recorded in the plan.

Both rounds were `good_enough` rather than `proceed`: the gate's round budget is one per stage, so
the findings are read and applied rather than argued into another round.

## Release / deploy

- [x] No release needed. Nothing here ships in either half's artefact yet; the server's own version
      is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
