### PR TITLE
chore(release): extension 0.99.1

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to **CredsForDevs** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.99.1] — an internal failure tells the agent THAT, and the journal HOW
+
+### Fixed
+
+- **An agent was told how an action failed, not just that it had.** When something under a use
+  action threw, the caught error’s own message went back over the wire — and a driver, a parser or
+  a filesystem call names paths, versions, table names and query fragments in the text it raises.
+  The agent now gets a fixed sentence and the same error CODE it always got; the reason moves to
+  the agent journal, which is on this machine and is where you look when an agent reports a
+  failure.
+
+- **…and the reason is masked on the way there.** A driver's message is exactly where a credential
+  turns up, so it goes through the same masker that strips secrets out of command output before it
+  reaches the journal.
+
+- **A refused use now records which door it arrived by**, like every other refusal in that journal.
+  It was the one kind that did not.
+
+_Closes the CodeQL `js/stack-trace-exposure` alert. `0.99.0` shipped without these, so the two
+builds get different version strings — one string, one build._
+
 ## [0.99.0] — a PIN on an entry, and on everything in a folder
 
 ### Added

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Zero-trust credential manager for developers: SSH hosts and keys, VPN configs, databases, scripts and the CLI commands nobody remembers — in VS Code. Secrets live in the OS keychain; sync and team sharing are end-to-end encrypted, so the self-hosted vault server never sees plaintext. An AI coding agent can use an SSH credential without ever receiving it.",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
`extension-v0.99.0` was tagged and released **before** the CodeQL `js/stack-trace-exposure` fix
(#20) landed, so `main` now carries extension bytes the tag does not:

```
git diff extension-v0.99.0..main -- src_vs_code/src
  brokerResponse.ts     +25
  credsAgentServer.ts   +19 / -8
```

One version string, one build. The two get different strings rather than both answering to
`0.99.0` — that is what makes "fixed in 0.99.1" a checkable sentence six months from now, and the
shared git-workflow rule says to take the bump even for a build only one person installed.

## What is in it

No code — a version and its changelog entry. The code is #20, already on `main`:

- an agent is told THAT an action failed and not HOW (a fixed sentence and the same error code;
  the reason moves to the local journal);
- the reason is masked on the way to the journal, because a driver's message is exactly where a
  credential turns up;
- a refused *use* records which door it arrived by, like every other refusal in that journal.

## Test plan — observed

```
npm test    3204 tests · 3200 pass · 0 fail · 4 skipped   (on main, at the merge of #20)
```

The changelog slicer was run over three versions after the edit — the release workflow cuts notes
between `## [` headings, and shared git-workflow rule 11 exists because a merge once put an
unbracketed heading between two versions:

```
0.99.1  22 lines  clean
0.99.0  64 lines  clean
0.98.0  53 lines  clean
```

## Review gate

**Not applicable, and said rather than omitted** (`pull-requests.md` §2): a version string and a
changelog entry. There is no product diff for the `coai` gate to read — the code it would have read
went through the gate as #20 (plan round 10 findings, code round 11 findings, verdict `proceed`).

The tag is cut on `main` after this merges, never on the branch.
