### PR TITLE
feat(org): registration on first sync, the policy document, and the contract-3 floor

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -13,6 +13,7 @@ writing the endpoint, or run the whole tree headless before a release.
 | [`shares/`](shares) | `/api/shares`, `/api/shares/sent`, and both withdrawal paths |
 | [`metrics/`](metrics) | `/api/metrics` |
 | [`org-recovery/`](org-recovery) | the eleven corporate-recovery routes |
+| [`org/`](org) | `/api/org/me` — the corporate surface; the next epics add their routes here |
 
 ## This repository has a SECOND HTTP surface, and it is not here
 
@@ -28,7 +29,7 @@ grant, and `call()` does a real `fetch` against `http://127.0.0.1:<port>`. **65 
 way across `credsAgentServer.test.ts` and `brokerMcpRoutes.test.ts`.
 
 Written down because the numbers below invite the wrong conclusion: `http-coverage.mjs` reads C# and
-Rust route registrations, so its verdict for this repository — 26 of 26 — is a statement about the
+Rust route registrations, so its verdict for this repository — 27 of 27 — is a statement about the
 **vault server** and says nothing at all about the extension's API. An armed coverage check is not a
 claim that every HTTP surface in a repository has a suite.
 
@@ -47,7 +48,7 @@ precondition genuinely changed.
 |---|---|
 | `Auth:Local:SigningKey` ≥ 32 bytes, and the same value in `VAULT_LOCAL_SIGNING_KEY` | Microsoft and Google tokens exist only after an interactive sign-in. The `Local` scheme is symmetric, so the suite signs its own tokens — which is what makes every authenticated request runnable headless. |
 | `Vault:AllowedDomains=example.com` | The 403 branch is *"your token is fine and your domain is not served here"*. Reaching it needs a domain the server refuses, so it needs a domain it accepts. |
-| `Vault:CorpRecovery:OfficerEmails=officer@example.com,officer2@example.com` | `/api/metrics` and every recovery lever are officer-only. Without a roster the server answers 403 to everyone, and the officer requests fail for an environmental reason. |
+| `Vault:CorpRecovery:OfficerEmails=officer@example.com,officer2@example.com,officer3@example.com` | `/api/metrics` and every recovery lever are officer-only, and `org/` needs corp mode on. **Three, not two**: the quorum guard turns a smaller roster OFF (`OrgRecoveryConfig.MinimumOfficers`), so a two-officer environment runs the whole suite against a personal server — the officer requests fail for an environmental reason, and `org/me.http`'s 426 never fires. CI uses the same three. |
 | A **fresh** `Vault:DataDir` | `vault/vault.http` opens with "there is no vault yet". The file deletes what it created, so a completed run leaves the store as it found it; an interrupted one does not. |
 
 **The signing key is never in this repository.** Whoever holds it can mint a token for any email on
@@ -63,7 +64,7 @@ npm install --save-dev httpyac@6.16.7            # once per machine
 export VAULT_LOCAL_SIGNING_KEY="$(openssl rand -base64 48)"
 Auth__Local__SigningKey="$VAULT_LOCAL_SIGNING_KEY" \
 Vault__AllowedDomains=example.com \
-Vault__CorpRecovery__OfficerEmails=officer@example.com,officer2@example.com \
+Vault__CorpRecovery__OfficerEmails=officer@example.com,officer2@example.com,officer3@example.com \
 Vault__DataDir=/tmp/vault-suite \
 Vault__PublishInstanceFile=false \
   dotnet run --project src_minimalapi_server/src --urls http://127.0.0.1:5099 &

--- a/http/httpyac.config.js
+++ b/http/httpyac.config.js
@@ -39,8 +39,10 @@ module.exports = {
       baseUrl: process.env.VAULT_BASE_URL ?? 'http://127.0.0.1:5099',
 
       // The contract version this suite speaks. Sent on every request so the suite is a client
-      // like any other — and so a future 426 is something the suite can be made to provoke.
-      contract: '2',
+      // like any other — and so a 426 is something the suite can provoke (org/me.http does).
+      // Pinned to the server's current contract because the suite runs against a CORP-MODE server
+      // (see README.md), where the floor is 3: left at '2', every request in this tree answers 426.
+      contract: '3',
 
       aliceEmail: `alice@${DOMAIN}`,
       bobEmail: `bob@${DOMAIN}`,

--- a/http/org/me.http
+++ b/http/org/me.http
@@ -119,18 +119,25 @@ X-Creds-Contract: {{contract}}
 # raises the floor to 3, and a contract-2 client — which does not know this route exists — is refused
 # before authentication with a sentence that says why. The platform group declares 426 uncovered
 # because on a PERSONAL server it needs a raised configuration; here it needs only a roster.
+# JSON, unlike the same refusal on every older route: this surface promises {error} everywhere, and
+# the middleware answers before any of its endpoints can.
 # @name org_me_from_a_contract_2_client_is_426_on_a_corp_server
 GET {{baseUrl}}/api/org/me
 Authorization: Bearer {{token}}
 X-Creds-Contract: 2
 
 ?? status == 426
+?? header content-type matches ^application\/json
 
 {{
   const assert = require('node:assert');
-  test('the refusal names the policy document the old client cannot read, and what to do', () => {
-    assert.ok(response.body.includes('policy'), `426 body says nothing about why: ${response.body}`);
-    assert.ok(response.body.includes('update the extension'));
+  test('the refusal is an {error} the admin UI can show', () => {
+    assert.strictEqual(typeof response.parsedBody.error, 'string');
+  });
+  test('and it names the policy document the old client cannot read, and what to do', () => {
+    const why = response.parsedBody.error;
+    assert.ok(why.includes('policy'), `426 body says nothing about why: ${why}`);
+    assert.ok(why.includes('update the extension'));
   });
 }}
 

--- a/http/org/me.http
+++ b/http/org/me.http
@@ -1,0 +1,141 @@
+# The corporate surface — GET /api/org/me, the one document every client reads each cycle: who the
+# caller is to this server (role, active, officer), what an honest client does about it (the policy),
+# and the offline lease. A DOCUMENT THE CLIENT OBEYS, not a boundary the server holds: export, local
+# backup and moving an entry out of a project happen inside the extension, where the server cannot see
+# them, so nothing here stops a developer with a valid token and curl. The rules the server does enforce
+# land at POST /api/shares and in the caller gate in later epics.
+#
+# PRECONDITION: this suite runs against a corp-mode server (see ../README.md — a roster with
+# officer@<domain> on it), so `corpMode` is true here, and the contract-3 floor is live — which is what
+# makes the 426 below a real request rather than a declaration. On a personal server the same route
+# answers `corpMode: false` with inert defaults, and the floor does not exist.
+
+# @name org_me_answers_the_callers_role_and_policy
+# @prod
+GET {{baseUrl}}/api/org/me
+Authorization: Bearer {{token}}
+X-Creds-Contract: {{contract}}
+Accept: application/json
+
+?? status == 200
+?? header content-type matches ^application\/json
+
+{{
+  const assert = require('node:assert');
+  const me = response.parsedBody;
+  test('corpMode is a boolean, and true here — the suite runs against a roster', () => {
+    assert.strictEqual(me.corpMode, true);
+  });
+  test('the email is the token\'s, never a claim in the request', () => {
+    assert.strictEqual(me.email, aliceEmail);
+  });
+  test('a person who only ever synced is a member, active, and not an officer', () => {
+    assert.ok(['admin', 'member', 'dev'].includes(me.role), `unknown role ${me.role}`);
+    assert.strictEqual(typeof me.active, 'boolean');
+    assert.strictEqual(typeof me.isOfficer, 'boolean');
+    assert.strictEqual(me.isOfficer, false);
+  });
+  test('the policy is derived on the server and carried whole — the client never re-derives it', () => {
+    assert.strictEqual(typeof me.policy, 'object');
+    assert.strictEqual(typeof me.policy.export, 'boolean');
+    assert.strictEqual(typeof me.policy.share, 'string');
+    assert.strictEqual(typeof me.policy.moveOutOfProject, 'boolean');
+  });
+  test('projects and pending removals are arrays — never null, whatever the record holds', () => {
+    assert.ok(Array.isArray(me.projects));
+    assert.ok(Array.isArray(me.pendingFolderRemovals));
+    assert.strictEqual(typeof me.shareDefault, 'string');
+  });
+  test('the lease, the login-key version and the server contract are numbers', () => {
+    assert.strictEqual(typeof me.offlineLeaseHours, 'number');
+    assert.ok(me.offlineLeaseHours >= 0, '0 is the legal "strictly online"; negative is not a lease');
+    assert.strictEqual(typeof me.loginKeyVersion, 'number');
+    assert.strictEqual(typeof me.serverContract, 'number');
+  });
+  test('serverContract repeats the response header, so a kept document says which server wrote it', () => {
+    assert.strictEqual(String(me.serverContract), response.headers['x-creds-contract']);
+  });
+}}
+
+###
+# The roster is configuration, not a registry record: an officer who never synced is still one, and
+# the client's admin predicate is `role === 'admin' || isOfficer`.
+# @name org_me_for_an_officer_says_so
+# @prod
+GET {{baseUrl}}/api/org/me
+Authorization: Bearer {{officerToken}}
+X-Creds-Contract: {{contract}}
+Accept: application/json
+
+?? status == 200
+
+{{
+  const assert = require('node:assert');
+  test('isOfficer is true for somebody on the roster', () => {
+    assert.strictEqual(response.parsedBody.isOfficer, true);
+  });
+  test('and their registry role is a separate fact, reported alongside', () => {
+    assert.ok(['admin', 'member', 'dev'].includes(response.parsedBody.role));
+  });
+}}
+
+###
+# Every refusal on /api/org/* is a JSON {error}, unlike the older endpoints' empty bodies: an admin
+# UI has to show WHY.
+# @name org_me_without_a_token_is_401_with_a_json_reason
+GET {{baseUrl}}/api/org/me
+X-Creds-Contract: {{contract}}
+
+?? status == 401
+?? header content-type matches ^application\/json
+
+{{
+  const assert = require('node:assert');
+  test('the body names the refusal', () => {
+    assert.strictEqual(typeof response.parsedBody.error, 'string');
+    assert.ok(response.parsedBody.error.length > 0);
+  });
+}}
+
+###
+# 403, not 401: the token is valid and the caller is simply not from a domain this deployment serves.
+# @name org_me_from_outside_the_allowed_domain_is_403_with_a_json_reason
+GET {{baseUrl}}/api/org/me
+Authorization: Bearer {{outsiderToken}}
+X-Creds-Contract: {{contract}}
+
+?? status == 403
+?? header content-type matches ^application\/json
+
+{{
+  const assert = require('node:assert');
+  test('the body names the refusal', () => {
+    assert.strictEqual(typeof response.parsedBody.error, 'string');
+  });
+}}
+
+###
+# The corp floor, provoked for real. Vault:MinimumClientContract is at its default; the roster alone
+# raises the floor to 3, and a contract-2 client — which does not know this route exists — is refused
+# before authentication with a sentence that says why. The platform group declares 426 uncovered
+# because on a PERSONAL server it needs a raised configuration; here it needs only a roster.
+# @name org_me_from_a_contract_2_client_is_426_on_a_corp_server
+GET {{baseUrl}}/api/org/me
+Authorization: Bearer {{token}}
+X-Creds-Contract: 2
+
+?? status == 426
+
+{{
+  const assert = require('node:assert');
+  test('the refusal names the policy document the old client cannot read, and what to do', () => {
+    assert.ok(response.body.includes('policy'), `426 body says nothing about why: ${response.body}`);
+    assert.ok(response.body.includes('update the extension'));
+  });
+}}
+
+###
+# @uncovered 503 — a member record this build cannot read (malformed JSON, a schema version above this
+#            build's, a file that will not open). Provoking it means corrupting a file under a running
+#            server, which is machinery this rule explicitly does not ask for; the server suite's
+#            OrgUnavailableTests writes the garbage and reads the 503, Retry-After and JSON body back.

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -20,7 +20,7 @@ whole server is ~2,100 lines.
 
 | File | Role |
 |---|---|
-| `src/Program.cs` | Configuration, startup guards, the pipeline, and all twenty-five endpoints |
+| `src/Program.cs` | Configuration, startup guards, the pipeline, the gates, and the twenty-five endpoints of the personal and recovery surfaces; the corporate routes are mapped from `OrgEndpoints.cs` |
 | `src/VaultStore.cs` | Filesystem storage: atomic writes, hashed paths, the crash sweep |
 | `src/VaultStoreOutbox.cs` | The sender's receipts, and the two sweeps that bound both sides |
 | `src/ShareMaintenance.cs` | The hourly pass: retire dealt-with receipts, prune what aged out |
@@ -34,6 +34,7 @@ whole server is ~2,100 lines.
 | `src/OrgMembersStore.cs` | One record per person under `org/members/`, read synchronously from a stat-checked cache, written read-modify-write under the vault's per-email lock |
 | `src/OrgSettingsStore.cs` | The runtime settings an admin edits without a restart (`org/settings.json`); absent answers the default and writes nothing |
 | `src/OrgEventLog.cs` | The append-only NDJSON event log, one file per UTC day under `org/events/` — the writer only; the reader is a later epic's |
+| `src/OrgEndpoints.cs` | The corporate surface `/api/org/*`, mapped from its own file (`Program.cs` is past the size ceiling and four more epics add routes): `GET /api/org/me`, the JSON `FailJson` every refusal there uses, and the registration hook `PUT /api/vault` calls. The gates stay in `Program.cs` and cross over as delegates in one `OrgEndpointDeps` record |
 | `src/Logging.cs` | Serilog wiring: the coloured console + the segmenting run file |
 | `src/AnsiConsoleSink.cs` | Hand-written ANSI colour (ported from the family — Serilog's own theme writes zero escapes once stdout is redirected, and a container's captured stdout always is) |
 | `src/DailyRunFileSink.cs` | A file per run, segmenting at UTC midnight (`00-00-00-<pid>.log` in the next day's folder) so a never-restarting container cannot grow one file for months |
@@ -83,9 +84,10 @@ identifier**, so there is nothing to tamper with.
 | `GET` | `/api/client-config` | none | `200` | `{microsoftScope}` from `Auth__Microsoft__ClientScope`, `""` when unset. See below |
 | `GET` | `/api/whoami` | any allowed caller | `200` | `{email, name, hasVault}` |
 | `GET` | `/api/vault` | token email | `200` bytes / `404` | `application/octet-stream` + an `ETag`; 404 means nothing stored yet |
-| `PUT` | `/api/vault` | token email | `204` | 1..`MaxVaultBytes`; `400` outside that. Honours `If-Match` / `If-None-Match`, `412` when the precondition fails |
-| `DELETE` | `/api/vault` | token email | `204` | Deletes the vault, its `.email` sidecar, and the whole inbox |
-| `GET` | `/api/team` | any allowed caller | `200` | `[{email}]` — vault owners in the caller's own domain |
+| `PUT` | `/api/vault` | token email | `204` | 1..`MaxVaultBytes`; `400` outside that. Honours `If-Match` / `If-None-Match`, `412` when the precondition fails. In corp mode the first write also **registers** the caller (below) |
+| `DELETE` | `/api/vault` | token email | `204` | Deletes the vault, its `.email` sidecar, the whole inbox — and the registry record |
+| `GET` | `/api/team` | any allowed caller | `200` | `[{email}]` — vault owners in the caller's own domain; in corp mode, minus anyone whose record says `active: false` or cannot be read |
+| `GET` | `/api/org/me` | any allowed caller | `200` / `503` | The role-and-policy document — **a document the client obeys, not a boundary the server holds**. Corp mode off → `corpMode: false` and inert defaults. Never writes. See below |
 | `GET` | `/api/org-recovery/config` | any allowed caller | `200` | The corporate-recovery roster this server runs under. See below |
 | `POST` | `/api/org-recovery/invites` | officer | `201` | One officer's sealed Shamir share; sender stamped |
 | `GET` | `/api/org-recovery/invites` | officer | `200` | Your own pending invites, **streamed** |
@@ -178,22 +180,116 @@ only signal there is, because nothing tells the sender.
 
 ### The contract version
 
-**Current: 2** — a share carries its `format` (above). Version 1 dropped it, which is why the bump
-is the first one the mechanism was actually built for: a client must know which version it is
+**Current: 3** — the server has a role-and-policy document, `GET /api/org/me` (below). A version-2
+client does not know the route exists, so on a server with a corporate roster it obeys no policy at
+all — not a garbled response but a missing one: it exports, shares and backs up exactly as before,
+and nothing on either side says so. That is the misreading the bump names. **2** was a share
+carrying its `format` (above): version 1 dropped it, and a client must know which version it is
 talking to *before* it seals, not after it fails.
 
 Every response carries `X-Creds-Contract: <server version>`; a client sends the same header.
-Below `Vault:MinimumClientContract` the middleware answers **`426` before authentication**, so an
-extension too old to be served is told THAT instead of a `401` about a token that was never the
-problem. A caller that sends nothing, or something a proxy mangled, is served — every extension
-released before this existed sends nothing.
+Below the minimum the middleware answers **`426` before authentication**, so an extension too old
+to be served is told THAT instead of a `401` about a token that was never the problem. A caller
+that sends nothing, or something a proxy mangled, is served — every extension released before this
+existed sends nothing, on a corp server too.
+
+**The minimum applied is the effective one, and corp mode floors it at 3.**
+`ContractVersion.MinimumFor(configured, corpMode)` is `Math.Max(configured, 3)` when a roster is
+configured and the configured value otherwise, so an operator's higher minimum stands and a
+personal server is exactly as before. The reason is narrower than "make the policy binding" — the
+policy is what an honest client obeys, not what the server enforces — but a client that cannot even
+read the document cannot be expected to obey any of it, and serving it would be serving a bypass
+while hiding that from whoever deployed the server. So the `426` body in corp mode says why:
+*"this server speaks contract 3 and no longer serves 2 — this server has a corporate roster, and a
+client below contract 3 cannot read the role and policy document (GET /api/org/me) every client
+here is expected to obey; update the extension."* The sentence is added only when the claim is
+below 3; an operator who configured 5 refuses a contract-4 client for their own reason. This is a
+hard cutover on the day a corp server upgrades (owner decision 12) and belongs in the release notes;
+the extension's `CLIENT_CONTRACT_VERSION` and `ORG_POLICY_CONTRACT` moved to 3 in the same change,
+because a gap between the two halves is a window in which this repository's own extension is
+refused by its own server.
 
 It rides on a header rather than in `/api/client-config` because that endpoint documents its own
 reason for having exactly one field, and because a header means a client learns the version from
-a call it was already making. The default minimum equals the current version, so the refusal path
-is unreachable in production today — which is precisely why `Vault:MinimumClientContract` is
-configurable: a test raises it and drives a real refusal, instead of a branch nobody has ever seen
-run being discovered wrong on the day it first matters.
+a call it was already making. The default minimum stays 1, so on a personal server the refusal
+path is reachable only through configuration — which is precisely why `Vault:MinimumClientContract`
+is configurable: a test raises it and drives a real refusal, instead of a branch nobody has ever
+seen run being discovered wrong on the day it first matters. On a corp server the floor makes the
+refusal real with no configuration at all, and `http/org/me.http` provokes it over the wire.
+
+### `GET /api/org/me` — a document the client obeys, not a boundary
+
+```json
+{
+  "corpMode": true,
+  "email": "dev@company.com", "role": "member", "active": true,
+  "isOfficer": false,
+  "shareDefault": "project",
+  "projects": [], "pendingFolderRemovals": [],
+  "policy": { "export": true, "share": "any", "moveOutOfProject": true },
+  "offlineLeaseHours": 24,
+  "loginKeyVersion": 0,
+  "serverContract": 3
+}
+```
+
+The one document every client reads each cycle, in corp mode and out of it. Everything in it is
+what the shipped extension is expected to act on — export, local backup and moving an entry out of
+a project happen inside the extension, where the server cannot see them — so nothing here stops a
+developer holding a valid token and `curl`. The umbrella plan's *Boundaries* table grades every
+rule; the ones the server does enforce land at `POST /api/shares` and in the caller gate in the
+next epics. Written down here because the natural mistake is to later "fix" a client-side ban by
+moving it to a server that cannot observe the thing it would be banning.
+
+- **Corp mode off** (`orgRecovery.Enabled` false — the roster is the switch, there is no second
+  flag) answers `corpMode: false` and the defaults computed from constants, and consults nothing:
+  a personal server is indistinguishable from one that never had a registry, whatever a leftover
+  file under `org/` says. A test writes Alice as a blocked developer and reads back a member.
+- **Never registered** — no record on disk — answers the *computed* default: `member`, active, no
+  projects, the default lease. **It writes nothing.** This is `OrgRecoveryConfig.Read`'s "off is
+  the shape, not a flag" applied to a person: the answer is correct before the disk agrees, and a
+  token that stored nothing gets no file — not even the directory.
+- **A record this build cannot read** answers **`503`** with `Retry-After: 60` and a JSON
+  `{error}`, never the member default. The plan round's finding: not registered means the default,
+  the default is `member`, and a member may export — so "treat an unparseable record as not
+  registered" was a privilege escalation with a corrupted file as its trigger. One bad file costs
+  one person a refusal an operator can fix (the store already logged the path at Error); it must
+  not buy a developer an export.
+- `isOfficer` comes from the roster, `role` from the record: two facts from two sources, both
+  reported, because the client's admin predicate is `role === 'admin' || isOfficer` and an officer
+  cannot be given a registry role. `offlineLeaseHours` is `OrgSettingsStore`'s current value;
+  `policy` is derived from the role on every call and never stored; `serverContract` repeats the
+  response header so a kept document says which server wrote it.
+- **Every refusal on `/api/org/*` is a JSON `ErrorDto`** — the `401` and `403` from the shared
+  gate included — through `OrgEndpoints.FailJson`, the sibling of `Program.cs`'s plain-text `Fail`.
+  An admin UI has to show *why*; the older endpoints keep their empty bodies because their clients
+  were written against them.
+
+**Registration happens on the first vault write, not on the first authenticated call.**
+`PUT /api/vault` calls `OrgEndpoints.RegisterOnSyncAsync` right after `RecordOwnerAsync`, in corp
+mode only. It looks the caller up first and writes only when there is **no record**: the plan spelt
+the hook as an unconditional identity upsert, and that was watched doing the wrong thing — the
+store stamps every write, so a sync re-stamped a record an admin had edited (`updatedBy` became
+`""`, `updatedAt` the time of the sync) and the admin list would have shown that nobody changed the
+role, at a time nobody did. A record that exists is left alone; one that cannot be read is logged
+and left alone too (a default written over a blocked developer's unreadable record is an unblock
+nobody ordered). On the write that creates a record, one `member.registered` row is appended to the
+event log with the person as actor and the default role as detail — and only on that write, so the
+log does not grow by one row per sync. **The hook can never fail the response it rides on:** the
+vault has already landed, so a registry write that throws — disk full, a lock, a permission, a file
+where `org/members` should be a directory — is logged at Error and swallowed, and the next sync is
+the retry. Watched failing without the catch: a stored vault answered `500`.
+
+**`/api/team` is filtered, not replaced.** Personal mode is byte-identical (sidecars, domain
+filter, `[{email}]`). In corp mode an owner whose record says `active: false` — the behaviour epic
+2 gives the field — is dropped, and so is one whose record cannot be read: the caller gate will
+refuse that person, so a share to them would wait in an inbox nobody can open, and "unreadable"
+must never read as "fine". A person with no record is listed; the default is active. The DTO is not
+widened here — the role and the projects join it in epic 3, which needs them for its own filtering.
+
+**`DELETE /api/vault` takes the registry record with the vault**, so the registry cannot outgrow
+the people it describes. Not gated on corp mode: a record left behind by a roster since removed is
+still one to remove, and where no `org/` exists this is one stat and nothing else.
 
 ### `/api/org-recovery/config` — and why it is not officer-only
 
@@ -453,8 +549,11 @@ Every write is atomic: write `<path>.<random>.tmp`, then `File.Move(overwrite: t
 therefore never sees a partial blob, which is what lets `deploy/backup.sh` archive a live server.
 
 `org/` appears only when something is written into it — a personal deployment never has one, which is
-how an operator looking at the disk can tell a server with a roster from one without. Three things
-about what is under it, none of which has an endpoint yet:
+how an operator looking at the disk can tell a server with a roster from one without. The first
+write is a person's first vault sync on a corp server (`org/members/`, and the day's `org/events/`
+file for the `member.registered` row); reading `GET /api/org/me` creates nothing, and the three
+stores are constructed on every deployment without creating their directories. Three things about
+what is under it:
 
 - **A member record this build cannot read is *unavailable*, never *not registered*.** Not registered
   means the default role, and the default may export, so a malformed file, an unreadable one, one
@@ -498,11 +597,12 @@ about what is under it, none of which has an endpoint yet:
   when its owner acted — so one that reached `MaxInboxItems` refused every later share with `409`,
   a failure the SENDER saw about a state only the recipient could clear.
 - **`/api/team` enumerates.** Any authenticated caller can list every colleague's email. That is the
-  feature, but it is worth knowing it is also directory enumeration for anyone inside the domain.
+  feature, but it is worth knowing it is also directory enumeration for anyone inside the domain. In
+  corp mode the list is narrower — blocked and unreadable records are absent — but no wider.
 
 ## Tests
 
-`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 207 tests, ~8 s. The
+`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 227 tests, ~10 s. The
 endpoint suites run in-process through `WebApplicationFactory` — no free port, no background
 `dotnet run`; the store suites drive a store directly on a throwaway data directory.
 
@@ -517,8 +617,13 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 |---|---|
 | `HealthTests` | Public reachability, storage-writability reporting |
 | `AuthenticationTests` | No token, foreign domain, `alg=none`, wrong key, no email claim, expired |
-| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload |
+| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload, deleting a vault removes the registry record |
 | `TeamTests` | Owners listed, non-owners absent, deletion drops out |
+| `TeamCorpTests` | An inactive member is absent in corp mode and present in personal mode; the shape for an old client is `[{email}]` and byte-identical across the two modes |
+| `ContractVersionTests` | The header on every response, silent and garbled and newer clients served, a configured minimum refuses with a reason, the refusal precedes authentication; corp mode floors the minimum at 3 with the default configuration, the refusal names the policy, personal mode is unchanged, a corp server still serves a contract-3 client and a silent one, the floor never lowers a higher configured minimum |
+| `OrgMembersTests` | Registration on the first vault write and not on `/api/org/me`; the default role is member; a second sync does not re-stamp a record an admin edited; personal mode creates no `org/` and answers `corpMode: false` from constants whatever a leftover record says; a never-synced caller is computed and nothing is written; an officer reads `isOfficer: true` with no registry row |
+| `OrgRegistrationTests` | A registry that cannot be written (`org/members` is a file) does not fail the vault write; the next sync registers the person after all; two syncs leave exactly one `member.registered` row |
+| `OrgUnavailableTests` | A corrupted record makes `/api/org/me` answer `503` with `Retry-After` and a JSON body — never the member default; a sync never overwrites a record it cannot read, and still stores the vault |
 | `SharingTests` | Delivery, sender stamping, cross-domain refusal, traversal ids, recipient-only delete |
 | `RateLimitTests` | One caller cannot lock out another; a caller who overruns is still throttled |
 | `ForwardedHttpsTests` | A missing header is refused; health stays exempt |

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -275,7 +275,10 @@ role, at a time nobody did. A record that exists is left alone; one that cannot 
 and left alone too (a default written over a blocked developer's unreadable record is an unblock
 nobody ordered). On the write that creates a record, one `member.registered` row is appended to the
 event log with the person as actor and the default role as detail — and only on that write, so the
-log does not grow by one row per sync. **The hook can never fail the response it rides on:** the
+log does not grow by one row per sync. The record is written before the row, so a crash between
+the two costs one row and never a duplicate: the row rides on `Created`, which the store computes
+inside the per-member lock, and two devices syncing for the first time at once leave one row.
+**The hook can never fail the response it rides on:** the
 vault has already landed, so a registry write that throws — disk full, a lock, a permission, a file
 where `org/members` should be a directory — is logged at Error and swallowed, and the next sync is
 the retry. Watched failing without the catch: a stored vault answered `500`.
@@ -289,7 +292,11 @@ widened here — the role and the projects join it in epic 3, which needs them f
 
 **`DELETE /api/vault` takes the registry record with the vault**, so the registry cannot outgrow
 the people it describes. Not gated on corp mode: a record left behind by a roster since removed is
-still one to remove, and where no `org/` exists this is one stat and nothing else.
+still one to remove, and where no `org/` exists this is one stat and nothing else. Vault first, then
+the record, and the vault decides the response: `RemoveAsync` swallows a lock or a permission itself
+and logs at Error naming the person, so a registry the OS will not release cannot turn a delete that
+happened into a `500`. The surviving state is a record with no vault — the admin list shows it, and
+the next `DELETE` or an admin removes it.
 
 ### `/api/org-recovery/config` — and why it is not officer-only
 
@@ -602,7 +609,7 @@ what is under it:
 
 ## Tests
 
-`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 227 tests, ~10 s. The
+`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 242 tests, ~13 s. The
 endpoint suites run in-process through `WebApplicationFactory` — no free port, no background
 `dotnet run`; the store suites drive a store directly on a throwaway data directory.
 
@@ -617,13 +624,15 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 |---|---|
 | `HealthTests` | Public reachability, storage-writability reporting |
 | `AuthenticationTests` | No token, foreign domain, `alg=none`, wrong key, no email claim, expired |
-| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload, deleting a vault removes the registry record |
+| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload, deleting a vault removes the registry record, a registry removal the OS refuses does not fail the delete |
 | `TeamTests` | Owners listed, non-owners absent, deletion drops out |
 | `TeamCorpTests` | An inactive member is absent in corp mode and present in personal mode; the shape for an old client is `[{email}]` and byte-identical across the two modes |
 | `ContractVersionTests` | The header on every response, silent and garbled and newer clients served, a configured minimum refuses with a reason, the refusal precedes authentication; corp mode floors the minimum at 3 with the default configuration, the refusal names the policy, personal mode is unchanged, a corp server still serves a contract-3 client and a silent one, the floor never lowers a higher configured minimum |
 | `OrgMembersTests` | Registration on the first vault write and not on `/api/org/me`; the default role is member; a second sync does not re-stamp a record an admin edited; personal mode creates no `org/` and answers `corpMode: false` from constants whatever a leftover record says; a never-synced caller is computed and nothing is written; an officer reads `isOfficer: true` with no registry row |
-| `OrgRegistrationTests` | A registry that cannot be written (`org/members` is a file) does not fail the vault write; the next sync registers the person after all; two syncs leave exactly one `member.registered` row |
+| `OrgRegistrationTests` | A registry that cannot be written (`org/members` is a file) does not fail the vault write; the next sync registers the person after all; two syncs leave exactly one `member.registered` row and the second emits nothing; two concurrent first syncs leave one row and one record; the swallowed failure is logged at Error naming the person |
+| `OrgMeAuthorizationTests` | No token → `401` with a JSON body; an outside-domain token → `403` with a JSON body and nothing registered; an email differing only in case and surrounding space resolves to one record, end to end |
 | `OrgUnavailableTests` | A corrupted record makes `/api/org/me` answer `503` with `Retry-After` and a JSON body — never the member default; a sync never overwrites a record it cannot read, and still stores the vault |
+| `AppJsonContextTests` | Every DTO the org routes and their refusals serialize, lists included, is in the source-generated context — the one class of bug the endpoint suites cannot see, because under JIT an unregistered type falls through to reflection and only the AOT binary fails |
 | `SharingTests` | Delivery, sender stamping, cross-domain refusal, traversal ids, recipient-only delete |
 | `RateLimitTests` | One caller cannot lock out another; a caller who overruns is still throttled |
 | `ForwardedHttpsTests` | A missing header is refused; health stays exempt |
@@ -633,7 +642,7 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 | `InstanceFileTests` | The instance-file publish/withdraw lifecycle |
 | `ClientConfigTests`, `HealthProbeUrlTests` | (nested in `HealthTests.cs`) the advertised scope, and the probe URL |
 | `MemberPolicyTests` | The role → policy table: admin and member unrestricted whatever the share default, both developer share defaults, an unknown role or share default gets the most restrictive policy, the default role is member |
-| `OrgMembersStoreTests` | The registry: answered from the cache (a missing record too), the stat check sees an outside write and a record that appears, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), a record whose email does not hash to its file is unavailable, schema version — with only known fields too — refuses whole, unknown fields carried, `@domain` accepted, no `org/` until a write |
+| `OrgMembersStoreTests` | The registry: answered from the cache (a missing record too), the stat check sees an outside write and a record that appears, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), a record whose email does not hash to its file is unavailable, schema version — with only known fields too — refuses whole, unknown fields carried, `@domain` accepted, no `org/` until a write, a record the OS will not delete is logged at Error naming the person |
 | `OrgSettingsStoreTests` | The default without a file and no write, write then read, a malformed or unopenable file answers the last value this process read (the default only when it never read one), logged once, an outside write is seen |
 | `OrgEventLogTests` | Append and read back, the UTC day boundary, a torn tail gets its newline, the bounded lock, an unwritable folder is logged not thrown, two instances over one directory lose no row, both sweeps leave `org/events/` alone |
 

--- a/research/module_server.md
+++ b/research/module_server.md
@@ -202,8 +202,12 @@ read the document cannot be expected to obey any of it, and serving it would be 
 while hiding that from whoever deployed the server. So the `426` body in corp mode says why:
 *"this server speaks contract 3 and no longer serves 2 — this server has a corporate roster, and a
 client below contract 3 cannot read the role and policy document (GET /api/org/me) every client
-here is expected to obey; update the extension."* The sentence is added only when the claim is
-below 3; an operator who configured 5 refuses a contract-4 client for their own reason. This is a
+here is expected to obey; update the extension."* The sentence is built from `OrgPolicyContract`,
+not typed, so a later cutover cannot advertise a stale number, and it is added only when the claim
+is below 3; an operator who configured 5 refuses a contract-4 client for their own reason. **On
+`/api/org/*` the `426` is a JSON `{error}`**, because that surface promises one on every refusal and
+the middleware answers before any of its endpoints can; every older route — `/api/org-recovery/*`
+included, a shared prefix and none of the shape — keeps the plain sentence byte for byte. This is a
 hard cutover on the day a corp server upgrades (owner decision 12) and belongs in the release notes;
 the extension's `CLIENT_CONTRACT_VERSION` and `ORG_POLICY_CONTRACT` moved to 3 in the same change,
 because a gap between the two halves is a window in which this repository's own extension is
@@ -250,35 +254,43 @@ moving it to a server that cannot observe the thing it would be banning.
   the shape, not a flag" applied to a person: the answer is correct before the disk agrees, and a
   token that stored nothing gets no file — not even the directory.
 - **A record this build cannot read** answers **`503`** with `Retry-After: 60` and a JSON
-  `{error}`, never the member default. The plan round's finding: not registered means the default,
-  the default is `member`, and a member may export — so "treat an unparseable record as not
-  registered" was a privilege escalation with a corrupted file as its trigger. One bad file costs
-  one person a refusal an operator can fix (the store already logged the path at Error); it must
-  not buy a developer an export.
+  `{error}` that says an administrator must repair it — never the member default, and never the
+  file, which stays in the log. The plan round's finding: not registered means the default, the
+  default is `member`, and a member may export — so "treat an unparseable record as not registered"
+  was a privilege escalation with a corrupted file as its trigger. One bad file costs one person a
+  refusal an administrator can end (the store already logged the path at Error); it must not buy a
+  developer an export.
 - `isOfficer` comes from the roster, `role` from the record: two facts from two sources, both
   reported, because the client's admin predicate is `role === 'admin' || isOfficer` and an officer
   cannot be given a registry role. `offlineLeaseHours` is `OrgSettingsStore`'s current value;
   `policy` is derived from the role on every call and never stored; `serverContract` repeats the
   response header so a kept document says which server wrote it.
 - **Every refusal on `/api/org/*` is a JSON `ErrorDto`** — the `401` and `403` from the shared
-  gate included — through `OrgEndpoints.FailJson`, the sibling of `Program.cs`'s plain-text `Fail`.
-  An admin UI has to show *why*; the older endpoints keep their empty bodies because their clients
-  were written against them.
+  gate included, and the contract middleware's `426` — through `OrgEndpoints.FailJson`, the sibling
+  of `Program.cs`'s plain-text `Fail`. An admin UI has to show *why*; the older endpoints keep their
+  empty bodies and plain sentences because their clients were written against them.
 
 **Registration happens on the first vault write, not on the first authenticated call.**
 `PUT /api/vault` calls `OrgEndpoints.RegisterOnSyncAsync` right after `RecordOwnerAsync`, in corp
-mode only. It looks the caller up first and writes only when there is **no record**: the plan spelt
-the hook as an unconditional identity upsert, and that was watched doing the wrong thing — the
-store stamps every write, so a sync re-stamped a record an admin had edited (`updatedBy` became
-`""`, `updatedAt` the time of the sync) and the admin list would have shown that nobody changed the
-role, at a time nobody did. A record that exists is left alone; one that cannot be read is logged
-and left alone too (a default written over a blocked developer's unreadable record is an unblock
-nobody ordered). On the write that creates a record, one `member.registered` row is appended to the
-event log with the person as actor and the default role as detail — and only on that write, so the
-log does not grow by one row per sync. The record is written before the row, so a crash between
-the two costs one row and never a duplicate: the row rides on `Created`, which the store computes
-inside the per-member lock, and two devices syncing for the first time at once leave one row.
-**The hook can never fail the response it rides on:** the
+mode only. It writes only when there is **no record**, and the store decides that INSIDE the
+per-member lock (`OrgMembersStore.InsertIfAbsentAsync`): the plan spelt the hook as an unconditional
+identity upsert, and that was watched doing the wrong thing — the store stamps every write, so a
+sync re-stamped a record an admin had edited (`updatedBy` became `""`, `updatedAt` the time of the
+sync) and the admin list would have shown that nobody changed the role, at a time nobody did. A
+lookup before the upsert was the first fix, and that was watched too: with the lock held by a test,
+an admin's create landing between the lookup and the write was re-stamped all the same, so the
+decision moved inside the lock and the window is gone. A record that exists is left alone — not a
+byte, not its mtime; one that cannot be read is logged and left alone too (a default written over a
+blocked developer's unreadable record is an unblock nobody ordered). On the write that creates a
+record, one `member.registered` row is appended to the event log with the person as actor and the
+default role as detail — and only on that write, so the log does not grow by one row per sync. The
+record is written before the row, so a crash between the two costs one row and never a duplicate:
+the row rides on `Created`, computed under the lock, and two devices syncing for the first time at
+once leave one row. **The append takes no client token**: once the record exists the row is owed
+whoever is still listening, and a disconnect that cancelled it would lose the row for good, since
+every later sync finds the record and emits nothing (watched with the log's lock held by a test);
+the insert keeps the request's token, because a client that leaves before the record exists has
+lost nothing the next sync does not retry. **The hook can never fail the response it rides on:** the
 vault has already landed, so a registry write that throws — disk full, a lock, a permission, a file
 where `org/members` should be a directory — is logged at Error and swallowed, and the next sync is
 the retry. Watched failing without the catch: a stored vault answered `500`.
@@ -296,7 +308,10 @@ still one to remove, and where no `org/` exists this is one stat and nothing els
 the record, and the vault decides the response: `RemoveAsync` swallows a lock or a permission itself
 and logs at Error naming the person, so a registry the OS will not release cannot turn a delete that
 happened into a `500`. The surviving state is a record with no vault — the admin list shows it, and
-the next `DELETE` or an admin removes it.
+the next `DELETE` or an admin removes it. The removal takes **no client token**: the vault is already
+gone, so it is owed whether or not the client is still listening, and a disconnect that cancelled
+the wait would leave that record behind and throw out of a handler whose work had happened (watched
+with the lock held by a test); what that makes uncancellable is one lock held for a stat and an unlink.
 
 ### `/api/org-recovery/config` — and why it is not officer-only
 
@@ -609,7 +624,7 @@ what is under it:
 
 ## Tests
 
-`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 242 tests, ~13 s. The
+`src_minimalapi_server/tests/` — xUnit v3 on Microsoft Testing Platform, 252 tests, ~15 s. The
 endpoint suites run in-process through `WebApplicationFactory` — no free port, no background
 `dotnet run`; the store suites drive a store directly on a throwaway data directory.
 
@@ -624,14 +639,14 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 |---|---|
 | `HealthTests` | Public reachability, storage-writability reporting |
 | `AuthenticationTests` | No token, foreign domain, `alg=none`, wrong key, no email claim, expired |
-| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload, deleting a vault removes the registry record, a registry removal the OS refuses does not fail the delete |
+| `VaultTests` | Round-trip fidelity, per-caller isolation, size caps, survival after an oversize upload, deleting a vault removes the registry record, a registry removal the OS refuses does not fail the delete, a client hanging up mid-delete does not abandon the removal |
 | `TeamTests` | Owners listed, non-owners absent, deletion drops out |
 | `TeamCorpTests` | An inactive member is absent in corp mode and present in personal mode; the shape for an old client is `[{email}]` and byte-identical across the two modes |
-| `ContractVersionTests` | The header on every response, silent and garbled and newer clients served, a configured minimum refuses with a reason, the refusal precedes authentication; corp mode floors the minimum at 3 with the default configuration, the refusal names the policy, personal mode is unchanged, a corp server still serves a contract-3 client and a silent one, the floor never lowers a higher configured minimum |
+| `ContractVersionTests` | The header on every response, silent and garbled and newer clients served, a configured minimum refuses with a reason, the refusal precedes authentication; corp mode floors the minimum at 3 with the default configuration, the refusal names the policy, personal mode is unchanged, a corp server still serves a contract-3 client and a silent one, the floor never lowers a higher configured minimum, the reason names the floor from the constant, a corporate route's `426` is JSON while every older route's stays plain text |
 | `OrgMembersTests` | Registration on the first vault write and not on `/api/org/me`; the default role is member; a second sync does not re-stamp a record an admin edited; personal mode creates no `org/` and answers `corpMode: false` from constants whatever a leftover record says; a never-synced caller is computed and nothing is written; an officer reads `isOfficer: true` with no registry row |
-| `OrgRegistrationTests` | A registry that cannot be written (`org/members` is a file) does not fail the vault write; the next sync registers the person after all; two syncs leave exactly one `member.registered` row and the second emits nothing; two concurrent first syncs leave one row and one record; the swallowed failure is logged at Error naming the person |
+| `OrgRegistrationTests` | A registry that cannot be written (`org/members` is a file) does not fail the vault write; the next sync registers the person after all; two syncs leave exactly one `member.registered` row and the second emits nothing; two concurrent first syncs leave one row and one record; an admin creating the record in the hook's window keeps their stamp (the lock held by the test); a client hanging up after registration still gets its row; the swallowed failure is logged at Error naming the person |
 | `OrgMeAuthorizationTests` | No token → `401` with a JSON body; an outside-domain token → `403` with a JSON body and nothing registered; an email differing only in case and surrounding space resolves to one record, end to end |
-| `OrgUnavailableTests` | A corrupted record makes `/api/org/me` answer `503` with `Retry-After` and a JSON body — never the member default; a sync never overwrites a record it cannot read, and still stores the vault |
+| `OrgUnavailableTests` | A corrupted record makes `/api/org/me` answer `503` with `Retry-After` and a JSON body — never the member default; the body says an administrator must repair it and never names the file; a sync never overwrites a record it cannot read, and still stores the vault |
 | `AppJsonContextTests` | Every DTO the org routes and their refusals serialize, lists included, is in the source-generated context — the one class of bug the endpoint suites cannot see, because under JIT an unregistered type falls through to reflection and only the AOT binary fails |
 | `SharingTests` | Delivery, sender stamping, cross-domain refusal, traversal ids, recipient-only delete |
 | `RateLimitTests` | One caller cannot lock out another; a caller who overruns is still throttled |
@@ -642,7 +657,7 @@ Never `dotnet test` — there is no VSTest host here and it aborts.
 | `InstanceFileTests` | The instance-file publish/withdraw lifecycle |
 | `ClientConfigTests`, `HealthProbeUrlTests` | (nested in `HealthTests.cs`) the advertised scope, and the probe URL |
 | `MemberPolicyTests` | The role → policy table: admin and member unrestricted whatever the share default, both developer share defaults, an unknown role or share default gets the most restrictive policy, the default role is member |
-| `OrgMembersStoreTests` | The registry: answered from the cache (a missing record too), the stat check sees an outside write and a record that appears, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), a record whose email does not hash to its file is unavailable, schema version — with only known fields too — refuses whole, unknown fields carried, `@domain` accepted, no `org/` until a write, a record the OS will not delete is logged at Error naming the person |
+| `OrgMembersStoreTests` | The registry: answered from the cache (a missing record too), the stat check sees an outside write and a record that appears, the per-member lock keeps both of two concurrent edits, unreadable is unavailable (never the default), a record whose email does not hash to its file is unavailable, schema version — with only known fields too — refuses whole, unknown fields carried, `@domain` accepted, no `org/` until a write, a record the OS will not delete is logged at Error naming the person, insert-if-absent leaves an existing record untouched to the byte and the mtime, creates the default and says so, refuses an unreadable one |
 | `OrgSettingsStoreTests` | The default without a file and no write, write then read, a malformed or unopenable file answers the last value this process read (the default only when it never read one), logged once, an outside write is seen |
 | `OrgEventLogTests` | Append and read back, the UTC day boundary, a torn tail gets its newline, the bounded lock, an unwritable folder is logged not thrown, two instances over one directory lose no row, both sweeps leave `org/events/` alone |
 

--- a/src_minimalapi_server/src/AppJsonContext.cs
+++ b/src_minimalapi_server/src/AppJsonContext.cs
@@ -59,6 +59,11 @@ public sealed record ClientConfigDto(string MicrosoftScope);
 [JsonSerializable(typeof(MemberRecord))]
 [JsonSerializable(typeof(OrgSettingsDto))]
 [JsonSerializable(typeof(OrgEventDto))]
+[JsonSerializable(typeof(MemberSelfDto))]
+[JsonSerializable(typeof(ProjectSelfDto))]
+[JsonSerializable(typeof(PolicyDto))]
+[JsonSerializable(typeof(IReadOnlyList<ProjectSelfDto>))]
+[JsonSerializable(typeof(IReadOnlyList<PendingFolderRemoval>))]
 public sealed partial class AppJsonContext : JsonSerializerContext;
 
 /// <summary>The instance file's contract, indented for the human who opens it.</summary>

--- a/src_minimalapi_server/src/ContractVersion.cs
+++ b/src_minimalapi_server/src/ContractVersion.cs
@@ -36,8 +36,15 @@ public static class ContractVersion
     /// version it is talking to BEFORE it seals: against a version-1 server it seals with no AAD
     /// at all, because a binding the recipient cannot reconstruct is worse than none. That makes
     /// this the first bump the mechanism was actually built for.</para>
+    /// <para><b>3 — the server has a role-and-policy document, <c>GET /api/org/me</c>.</b> A
+    /// version-2 client does not know the route exists, so on a server with a corporate roster it
+    /// obeys no policy at all — not a garbled response but a missing one: it exports, shares and
+    /// backs up exactly as before, and nothing on either side says so. That is the misreading this
+    /// bump names. It is also why corp mode floors the minimum here (<see cref="OrgPolicyContract"/>)
+    /// where version 2 only asked to be detected: a client that cannot read the document cannot be
+    /// expected to obey it, and serving it would hide that from whoever deployed the server.</para>
     /// </remarks>
-    public const int Current = 2;
+    public const int Current = 3;
 
     /// <summary>
     /// The default oldest a client may be and still be served.
@@ -53,6 +60,32 @@ public static class ContractVersion
     /// With this, a test raises the minimum and drives a real refusal.</para>
     /// </remarks>
     public const int DefaultMinimumSupported = 1;
+
+    /// <summary>
+    /// The contract from which the role-and-policy document, <c>GET /api/org/me</c>, exists — and
+    /// therefore the floor on a server with a corporate roster.
+    /// </summary>
+    /// <remarks>
+    /// <para>Mirrors <c>ORG_POLICY_CONTRACT</c> in the extension's <c>contractVersion.ts</c>. A client
+    /// below it does not know the document is there, so on a server with a policy it obeys none of
+    /// it — and serving it would be serving a bypass while hiding that from whoever deployed the
+    /// server. Worth a <c>426</c>; not worth calling security, because the policy is what an honest
+    /// client obeys, not what the server enforces (the plan's <i>Boundaries</i> table).</para>
+    /// </remarks>
+    public const int OrgPolicyContract = 3;
+
+    /// <summary>The sentence a corp-mode refusal adds, so the body says WHY and not merely "too old".</summary>
+    public const string CorpFloorReason =
+        "this server has a corporate roster, and a client below contract 3 cannot read the role and "
+        + "policy document (GET /api/org/me) every client here is expected to obey";
+
+    /// <summary>
+    /// The minimum the middleware actually applies: the configured one, floored at
+    /// <see cref="OrgPolicyContract"/> in corp mode. <c>Math.Max</c>, never an assignment — an operator
+    /// who set the minimum higher must not be handed 3 back by the roster.
+    /// </summary>
+    public static int MinimumFor(int configured, bool corpMode) =>
+        corpMode ? Math.Max(configured, OrgPolicyContract) : configured;
 
     /// <summary>Sent by the client on every request, and by the server on every response.</summary>
     public const string Header = "X-Creds-Contract";
@@ -73,8 +106,19 @@ public static class ContractVersion
     /// Judge the header value.
     /// </summary>
     /// <param name="header">The raw <c>X-Creds-Contract</c> value, or null when absent.</param>
-    /// <param name="minimumSupported">From <c>Vault:MinimumClientContract</c>.</param>
-    public static Decision Judge(string? header, int minimumSupported = DefaultMinimumSupported)
+    /// <param name="minimumSupported">
+    /// The effective minimum — <see cref="MinimumFor"/> applied to <c>Vault:MinimumClientContract</c>.
+    /// </param>
+    /// <param name="corpReason">
+    /// In corp mode, the sentence that says WHY (<see cref="CorpFloorReason"/>); null in personal mode.
+    /// Added to the refusal only when the claim is below <see cref="OrgPolicyContract"/> — an operator
+    /// who configured a minimum of 5 refuses a contract-4 client for their own reason, and that client
+    /// can read the policy perfectly well.
+    /// </param>
+    public static Decision Judge(
+        string? header,
+        int minimumSupported = DefaultMinimumSupported,
+        string? corpReason = null)
     {
         if (!int.TryParse(header?.Trim(), out var claimed) || claimed <= 0)
         {
@@ -84,11 +128,14 @@ public static class ContractVersion
         }
         if (claimed < minimumSupported)
         {
-            return new Decision(
-                Verdict.TooOld,
-                claimed,
-                $"this server speaks contract {Current} and no longer serves {claimed}; update the extension");
+            return new Decision(Verdict.TooOld, claimed, RefusalText(claimed, corpReason));
         }
         return new Decision(Verdict.Serve, claimed, "compatible");
+    }
+
+    private static string RefusalText(int claimed, string? corpReason)
+    {
+        var why = corpReason is not null && claimed < OrgPolicyContract ? $" — {corpReason}" : string.Empty;
+        return $"this server speaks contract {Current} and no longer serves {claimed}{why}; update the extension";
     }
 }

--- a/src_minimalapi_server/src/ContractVersion.cs
+++ b/src_minimalapi_server/src/ContractVersion.cs
@@ -74,10 +74,14 @@ public static class ContractVersion
     /// </remarks>
     public const int OrgPolicyContract = 3;
 
-    /// <summary>The sentence a corp-mode refusal adds, so the body says WHY and not merely "too old".</summary>
-    public const string CorpFloorReason =
-        "this server has a corporate roster, and a client below contract 3 cannot read the role and "
-        + "policy document (GET /api/org/me) every client here is expected to obey";
+    /// <summary>
+    /// The sentence a corp-mode refusal adds, so the body says WHY and not merely "too old". Built from
+    /// the constant it names — a number typed into the text advertises a stale version the day the
+    /// constant moves, and a test moves it to prove this one follows.
+    /// </summary>
+    public static readonly string CorpFloorReason =
+        $"this server has a corporate roster, and a client below contract {OrgPolicyContract} cannot read "
+        + "the role and policy document (GET /api/org/me) every client here is expected to obey";
 
     /// <summary>
     /// The minimum the middleware actually applies: the configured one, floored at

--- a/src_minimalapi_server/src/OrgEndpoints.cs
+++ b/src_minimalapi_server/src/OrgEndpoints.cs
@@ -1,0 +1,232 @@
+using System.Globalization;
+using Microsoft.Extensions.Logging;
+
+namespace CredVaultServer;
+
+/// <summary>
+/// Who is calling, or nothing — and when nothing, the gate has already set the status. The shape of
+/// <c>RequireCaller</c> in <c>Program.cs</c>, crossing the file boundary as a delegate because the gates
+/// stay there, so one file still answers "who may do this".
+/// </summary>
+public delegate (string Email, string? Name)? CallerGate(HttpContext ctx);
+
+/// <summary>
+/// Everything the corporate routes need from <c>Program.cs</c>, as one record. The gates and
+/// <c>DomainOf</c> are local functions in a top-level program and cross into this file only as
+/// delegates; a record lets the next epics widen the set without editing the call site each time.
+/// <see cref="DomainOf"/> and <see cref="AllowAnyDomain"/> are carried for the admin routes the next
+/// story adds — the cross-domain refusal is theirs.
+/// </summary>
+public sealed record OrgEndpointDeps(
+    CallerGate RequireCaller,
+    Func<string, string> DomainOf,
+    OrgRecoveryConfig OrgRecovery,
+    OrgMembersStore Members,
+    OrgSettingsStore Settings,
+    OrgEventLog Events,
+    bool AllowAnyDomain,
+    ILogger Log,
+    int ServerContract);
+
+/// <summary>
+/// The corporate surface, <c>/api/org/*</c>, mapped from its own file.
+///
+/// <para><c>Program.cs</c> is past the coding-style ceiling already and four more epics add about
+/// twenty routes between them, so the corporate routes are registered from per-epic files starting
+/// with the first one — the way logic and storage are already split into <c>Org*.cs</c> /
+/// <c>Org*Store.cs</c>. The authorization gates do not move: they stay beside <c>RequireOfficer</c>.</para>
+///
+/// <para><b>Every refusal here is a JSON <see cref="ErrorDto"/>.</b> An admin UI has to show WHY, so
+/// <see cref="FailJson"/> is the sibling of <c>Program.cs</c>'s plain-text <c>Fail</c>; the older
+/// endpoints keep their shape, because their clients were written against it.</para>
+///
+/// <para><b>What this surface is not.</b> The document <c>GET /api/org/me</c> serves is what an honest
+/// client obeys — export, local backup and moving an entry out of a project happen inside the
+/// extension, where the server cannot see them. Nothing here stops a developer with a valid token and
+/// <c>curl</c>; the rules the server does enforce land at <c>POST /api/shares</c> and in the caller
+/// gate in later epics, and the umbrella plan's <i>Boundaries</i> table grades each one.</para>
+/// </summary>
+public static class OrgEndpoints
+{
+    /// <summary>
+    /// What the <c>503</c> tells a client about when to ask again. One constant, not a number at each
+    /// site. Sixty seconds rather than a few: the record can only be fixed by an operator, so a client
+    /// hammering the endpoint learns nothing sooner and logs the same Error line once per attempt.
+    /// </summary>
+    public const int UnavailableRetryAfterSeconds = 60;
+
+    public static WebApplication MapOrgEndpoints(this WebApplication app, OrgEndpointDeps deps)
+    {
+        // The one document every client reads each cycle — in corp mode and out of it. Any allowed
+        // caller; never writes (see MeAsync).
+        app.MapGet("/api/org/me", (HttpContext ctx, CancellationToken ct) => MeAsync(ctx, deps, ct));
+        return app;
+    }
+
+    /// <summary>
+    /// The JSON sibling of <c>Program.cs</c>'s <c>Fail</c>: a status and an <see cref="ErrorDto"/>, the
+    /// shape the exception handler already emits. The gate the next story adds calls this too — a gate
+    /// modelled on <c>RequireOfficer</c> would set a status and write nothing, and an empty <c>403</c> is
+    /// not the "why" this surface promises.
+    /// </summary>
+    public static Task FailJson(HttpContext ctx, int status, string message)
+    {
+        ctx.Response.StatusCode = status;
+        return ctx.Response.WriteAsJsonAsync(
+            new ErrorDto(message), AppJsonContext.Default.ErrorDto, cancellationToken: ctx.RequestAborted);
+    }
+
+    /// <summary>
+    /// The registration hook. <c>PUT /api/vault</c> calls it after the vault AND its owner sidecar have
+    /// landed, corp mode only: the umbrella's decision 2 words it "auto-registered on first sync", and
+    /// registering on every authenticated call would fill an admin's list with tokens that synced
+    /// nothing. Personal mode returns before touching anything, so no <c>org/</c> can appear there.
+    ///
+    /// <para><b>It may never fail the write it rides on.</b> By the time it runs the vault is stored, so
+    /// whatever the registry does — disk full, a lock, a permission, a record this build cannot read —
+    /// is logged at Error and swallowed. Answering <c>500</c> for a vault that was in fact stored is a
+    /// worse failure than an unregistered person: that is a state the design already handles, because
+    /// <c>GET /api/org/me</c> computes the default and the next sync retries this same idempotent write.
+    /// Watched failing without the catch: a file where <c>org/members</c> should be turned a stored vault
+    /// into a <c>500</c>.</para>
+    /// </summary>
+    public static async Task RegisterOnSyncAsync(OrgEndpointDeps deps, string email, CancellationToken ct)
+    {
+        if (!deps.OrgRecovery.Enabled)
+        {
+            return;
+        }
+        try
+        {
+            await RegisterIfAbsentAsync(deps, email, ct);
+        }
+        catch (MemberRecordUnavailableException e)
+        {
+            // The store refused to overwrite a record it cannot read — a default written over a blocked
+            // developer's unreadable record would be an unblock nobody ordered. The operator fixes the
+            // file; the person's vault is stored regardless.
+            deps.Log.LogError(e, "{Email} synced but was not registered: {Path} cannot be read and a sync must not overwrite it", email, e.FilePath);
+        }
+        catch (Exception e)
+        {
+            deps.Log.LogError(e, "{Email} synced but could not be registered; the vault write stands and the next sync retries", email);
+        }
+    }
+
+    /// <summary>
+    /// Only a person with NO record is written. The plan spelt the hook as an unconditional identity
+    /// upsert, and that was watched doing the wrong thing: <see cref="OrgMembersStore.UpsertAsync"/>
+    /// stamps every write, so a sync re-stamped a record an admin had edited — <c>updatedBy</c> became
+    /// the empty string and <c>updatedAt</c> the time of the sync, and the admin list would have shown
+    /// that nobody changed the role, at a time nobody did. So the lookup comes first. The window between
+    /// it and the write — an admin's first edit landing at the very instant of the person's first-ever
+    /// sync — costs at most that one stamp, and the role survives because the upsert reads inside the lock.
+    /// </summary>
+    private static async Task RegisterIfAbsentAsync(OrgEndpointDeps deps, string email, CancellationToken ct)
+    {
+        switch (deps.Members.Find(email).Status)
+        {
+            case MemberLookup.Found:
+                return;
+            case MemberLookup.Unavailable:
+                // Not an exception path — the store answered — but the same rule: never written over.
+                deps.Log.LogError("{Email} synced but was not registered: their record exists and cannot be read, and a sync must not overwrite it", email);
+                return;
+        }
+        var result = await deps.Members.UpsertAsync(email, r => r, byAdmin: string.Empty, ct);
+        if (result.Created)
+        {
+            await deps.Events.AppendAsync(Registered(result.Record), ct);
+        }
+    }
+
+    /// <summary>The row for a record the sync created: the person is the actor of their own registration.</summary>
+    private static OrgEventDto Registered(MemberRecord record) => new(
+        At: record.UpdatedAt,
+        Kind: OrgEventKinds.MemberRegistered,
+        Actor: record.Email,
+        Subject: record.Email,
+        Project: null,
+        ShareId: null,
+        EntityName: null,
+        EntityKind: null,
+        Outcome: null,
+        Detail: record.Role);
+
+    /// <summary>
+    /// <c>GET /api/org/me</c>. Corp mode off answers <c>corpMode: false</c> and the inert defaults from
+    /// the default record — and consults nothing, so a personal server is indistinguishable from one that
+    /// never had a registry, whatever a leftover file under <c>org/</c> says.
+    /// </summary>
+    private static async Task MeAsync(HttpContext ctx, OrgEndpointDeps deps, CancellationToken ct)
+    {
+        var caller = await RequireOrgCallerAsync(ctx, deps);
+        if (caller is null)
+        {
+            return;
+        }
+        if (!deps.OrgRecovery.Enabled)
+        {
+            await WriteAsync(ctx, MemberSelfDto.Personal(caller.Value.Email, deps.ServerContract), ct);
+            return;
+        }
+        await CorpMeAsync(ctx, deps, caller.Value.Email, ct);
+    }
+
+    /// <summary>
+    /// Three lookup answers, three branches, and the order they are written in is the finding of the
+    /// plan round: <see cref="MemberLookup.NotRegistered"/> is the computed default with NOTHING written —
+    /// a token that stored nothing gets no file — while <see cref="MemberLookup.Unavailable"/> is a
+    /// <c>503</c>, never the default, because the default is <c>member</c> and a member may export.
+    /// </summary>
+    private static Task CorpMeAsync(HttpContext ctx, OrgEndpointDeps deps, string email, CancellationToken ct) =>
+        deps.Members.Find(email) switch
+        {
+            { Status: MemberLookup.Unavailable } => FailUnavailable(ctx),
+            { Status: MemberLookup.Found, Record: { } record } => WriteAsync(ctx, Self(deps, record), ct),
+            _ => WriteAsync(ctx, Self(deps, MemberRecord.DefaultFor(email, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())), ct),
+        };
+
+    private static MemberSelfDto Self(OrgEndpointDeps deps, MemberRecord record) =>
+        MemberSelfDto.For(
+            record,
+            corpMode: true,
+            isOfficer: deps.OrgRecovery.IsOfficer(record.Email),
+            offlineLeaseHours: deps.Settings.Read().OfflineLeaseHours,
+            serverContract: deps.ServerContract);
+
+    private static Task WriteAsync(HttpContext ctx, MemberSelfDto self, CancellationToken ct) =>
+        ctx.Response.WriteAsJsonAsync(self, AppJsonContext.Default.MemberSelfDto, cancellationToken: ct);
+
+    /// <summary>
+    /// The shared gate decides and sets the status; this adds the body the corporate surface promises,
+    /// so a <c>401</c> or <c>403</c> here carries a sentence where the older endpoints carry none.
+    /// </summary>
+    private static async Task<(string Email, string? Name)?> RequireOrgCallerAsync(HttpContext ctx, OrgEndpointDeps deps)
+    {
+        var caller = deps.RequireCaller(ctx);
+        if (caller is null)
+        {
+            await FailJson(ctx, ctx.Response.StatusCode, RefusalReason(ctx.Response.StatusCode));
+        }
+        return caller;
+    }
+
+    private static string RefusalReason(int status) => status switch
+    {
+        StatusCodes.Status401Unauthorized => "No verified identity was presented.",
+        _ => "That account is not served by this deployment.",
+    };
+
+    private static Task FailUnavailable(HttpContext ctx)
+    {
+        ctx.Response.Headers.RetryAfter = UnavailableRetryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        // Names the problem and who fixes it, not the file: the path is the operator's business and is
+        // already in the server log at Error, written once by the store.
+        return FailJson(
+            ctx,
+            StatusCodes.Status503ServiceUnavailable,
+            "Your membership record cannot be read by this server. Nothing about your role can be answered "
+            + "until an operator fixes it; the server log names the file.");
+    }
+}

--- a/src_minimalapi_server/src/OrgEndpoints.cs
+++ b/src_minimalapi_server/src/OrgEndpoints.cs
@@ -114,29 +114,26 @@ public static class OrgEndpoints
     }
 
     /// <summary>
-    /// Only a person with NO record is written. The plan spelt the hook as an unconditional identity
-    /// upsert, and that was watched doing the wrong thing: <see cref="OrgMembersStore.UpsertAsync"/>
-    /// stamps every write, so a sync re-stamped a record an admin had edited — <c>updatedBy</c> became
-    /// the empty string and <c>updatedAt</c> the time of the sync, and the admin list would have shown
-    /// that nobody changed the role, at a time nobody did. So the lookup comes first. The window between
-    /// it and the write — an admin's first edit landing at the very instant of the person's first-ever
-    /// sync — costs at most that one stamp, and the role survives because the upsert reads inside the lock.
+    /// Only a person with NO record is written, and the decision is the store's, INSIDE the lock. The plan
+    /// spelt the hook as an unconditional identity upsert, and that was watched re-stamping a record an
+    /// admin had edited — <c>updatedBy</c> back to the empty string, <c>updatedAt</c> the time of the sync.
+    /// The first fix looked the caller up first, and that was watched too: with the per-member gate held
+    /// by a test, an admin's create landing between the lookup and the write was re-stamped all the same.
+    /// <see cref="OrgMembersStore.InsertIfAbsentAsync"/> decides with the gate held, so there is no window.
+    ///
+    /// <para>The insert takes the request's token: a client that hangs up before the record exists has
+    /// lost nothing, because the next sync retries this same idempotent write. The row does NOT — see
+    /// inside.</para>
     /// </summary>
     private static async Task RegisterIfAbsentAsync(OrgEndpointDeps deps, string email, CancellationToken ct)
     {
-        switch (deps.Members.Find(email).Status)
-        {
-            case MemberLookup.Found:
-                return;
-            case MemberLookup.Unavailable:
-                // Not an exception path — the store answered — but the same rule: never written over.
-                deps.Log.LogError("{Email} synced but was not registered: their record exists and cannot be read, and a sync must not overwrite it", email);
-                return;
-        }
-        var result = await deps.Members.UpsertAsync(email, r => r, byAdmin: string.Empty, ct);
+        var result = await deps.Members.InsertIfAbsentAsync(email, ct);
         if (result.Created)
         {
-            await deps.Events.AppendAsync(Registered(result.Record), ct);
+            // Once the record exists the row is owed whoever is still listening. Cancelled by a
+            // disconnect it is lost for good — every later sync finds the record and emits nothing — so
+            // the append gets no client token; its own five-second bound is what limits the wait.
+            await deps.Events.AppendAsync(Registered(result.Record), CancellationToken.None);
         }
     }
 
@@ -221,12 +218,13 @@ public static class OrgEndpoints
     private static Task FailUnavailable(HttpContext ctx)
     {
         ctx.Response.Headers.RetryAfter = UnavailableRetryAfterSeconds.ToString(CultureInfo.InvariantCulture);
-        // Names the problem and who fixes it, not the file: the path is the operator's business and is
-        // already in the server log at Error, written once by the store.
+        // Names the problem and WHO ends it — an administrator — so the person does not retry into the
+        // same wall; never the file, which is the operator's business and is already in the server log
+        // at Error, written once by the store.
         return FailJson(
             ctx,
             StatusCodes.Status503ServiceUnavailable,
-            "Your membership record cannot be read by this server. Nothing about your role can be answered "
-            + "until an operator fixes it; the server log names the file.");
+            "Your membership record cannot be read by this server, so nothing about your role can be "
+            + "answered. An administrator must repair it; the server log names the file.");
     }
 }

--- a/src_minimalapi_server/src/OrgMembers.cs
+++ b/src_minimalapi_server/src/OrgMembers.cs
@@ -267,3 +267,73 @@ public static class MemberPolicy
     private static string NormalizeShare(string shareDefault) =>
         ShareDefaults.IsKnown(shareDefault) ? shareDefault : ShareDefaults.None;
 }
+
+/// <summary>
+/// One project assignment as the client sees it. Only what THIS epic can know — the assignment; the
+/// project's <c>Name</c> joins in epic 3, which owns the project store. Named there as a build item,
+/// because a field in a documented response that no epic can fill is how a shape becomes a lie.
+/// </summary>
+public sealed record ProjectSelfDto(string ProjectId, string Share)
+{
+    public static ProjectSelfDto From(ProjectAssignment assignment) => new(assignment.ProjectId, assignment.Share);
+}
+
+/// <summary>
+/// The document every client reads each cycle — <c>GET /api/org/me</c>: who the caller is to this
+/// server, and what an honest client does about it.
+/// </summary>
+/// <remarks>
+/// <para><c>CorpMode</c> first, because it decides how the rest is read: <c>false</c> means every other
+/// field is the inert default and the client shows no corporate UI at all. <c>IsOfficer</c> rides
+/// beside <c>Role</c> because the two are different facts from different sources — the roster is
+/// configuration, the role is a record — and the client's admin predicate is
+/// <c>role === 'admin' || isOfficer</c>. <c>ServerContract</c> repeats the response header so a client
+/// that keeps the document can tell which server wrote it.</para>
+/// </remarks>
+public sealed record MemberSelfDto(
+    bool CorpMode,
+    string Email,
+    string Role,
+    bool Active,
+    bool IsOfficer,
+    string ShareDefault,
+    IReadOnlyList<ProjectSelfDto> Projects,
+    IReadOnlyList<PendingFolderRemoval> PendingFolderRemovals,
+    PolicyDto Policy,
+    int OfflineLeaseHours,
+    int LoginKeyVersion,
+    int ServerContract)
+{
+    /// <summary>The document for a record — stored or computed, the endpoint does not care which.</summary>
+    public static MemberSelfDto For(
+        MemberRecord record,
+        bool corpMode,
+        bool isOfficer,
+        int offlineLeaseHours,
+        int serverContract) => new(
+            CorpMode: corpMode,
+            Email: record.Email,
+            Role: record.Role,
+            Active: record.Active,
+            IsOfficer: isOfficer,
+            ShareDefault: record.ShareDefault,
+            Projects: [.. record.Projects.Select(ProjectSelfDto.From)],
+            PendingFolderRemovals: record.PendingFolderRemovals,
+            Policy: MemberPolicy.For(record.Role, record.ShareDefault),
+            OfflineLeaseHours: offlineLeaseHours,
+            LoginKeyVersion: record.LoginKeyVersion,
+            ServerContract: serverContract);
+
+    /// <summary>
+    /// What a server with no roster answers: the default record, no officer, the default lease. Computed
+    /// from constants and nothing else, so it cannot differ between a personal server that never had an
+    /// <c>org/</c> and one whose roster was removed — "corp mode off" has to mean off.
+    /// </summary>
+    public static MemberSelfDto Personal(string email, int serverContract) =>
+        For(
+            MemberRecord.DefaultFor(email, now: 0),
+            corpMode: false,
+            isOfficer: false,
+            offlineLeaseHours: OrgSettingsDto.DefaultOfflineLeaseHours,
+            serverContract: serverContract);
+}

--- a/src_minimalapi_server/src/OrgMembersStore.cs
+++ b/src_minimalapi_server/src/OrgMembersStore.cs
@@ -337,16 +337,22 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// behind a vault write for the same stripe.
     ///
     /// <para>Best-effort like <see cref="VaultStore.DeleteEverythingFor"/>, and unlike it, it says so: a
-    /// file that could not be deleted is logged rather than silently left to be listed.</para>
+    /// file that could not be deleted is logged rather than silently left to be listed. <b>Never throws
+    /// for a lock or a permission</b> — the caller has already deleted the vault, and a <c>500</c> for a
+    /// delete that in fact happened is the failure the registration hook was built not to produce. What
+    /// survives is a record with no vault; the admin list shows it, and the next <c>DELETE</c> or an admin
+    /// removes it. That line is therefore the operator's ONE signal about the state, so it is at Error and
+    /// names the person — a warning without a name is a line nobody acts on.</para>
     /// </summary>
     public async Task RemoveAsync(string email, CancellationToken ct)
     {
-        var key = VaultStore.KeyFor(MemberRecord.Normalize(email));
+        var normalized = MemberRecord.Normalize(email);
+        var key = VaultStore.KeyFor(normalized);
         var gate = VaultStore.GateFor(key);
         await gate.WaitAsync(ct);
         try
         {
-            var path = TargetFor(key, string.Empty).FilePath;
+            var path = TargetFor(key, normalized).FilePath;
             if (File.Exists(path))
             {
                 File.Delete(path);
@@ -355,7 +361,10 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
         }
         catch (Exception e) when (e is IOException or UnauthorizedAccessException)
         {
-            log.LogWarning(e, "member record for a deleted vault could not be removed; it stays listed until it is");
+            log.LogError(
+                e,
+                "member record for {Email} could not be removed after their vault was deleted; a record with no vault stays listed until the next DELETE or an admin removes it",
+                normalized);
         }
         finally
         {

--- a/src_minimalapi_server/src/OrgMembersStore.cs
+++ b/src_minimalapi_server/src/OrgMembersStore.cs
@@ -237,11 +237,53 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
     /// record is an unblock nobody ordered; <see cref="MemberRecordUnavailableException"/> names the file
     /// instead, the lock is released on the way out, and the operator fixes the file.</para>
     /// </summary>
-    public async Task<UpsertResult> UpsertAsync(
+    public Task<UpsertResult> UpsertAsync(
         string email,
         Func<MemberRecord, MemberRecord> edit,
         string byAdmin,
-        CancellationToken ct)
+        CancellationToken ct) =>
+        UnderGateAsync(email, ct, (current, normalized, now, path) =>
+        {
+            var (baseline, created) = Baseline(current, normalized, now, path);
+            return new WritePlan(Stamp(edit(baseline), normalized, byAdmin, now), created, Write: true);
+        });
+
+    /// <summary>
+    /// The sync hook's write: create the default record if there is none, and if there is one, answer it
+    /// UNTOUCHED — no write, no stamp, <see cref="UpsertResult.Created"/> false.
+    ///
+    /// <para>Decided inside the lock, and that is the whole point of a second method rather than
+    /// <c>Find</c> followed by <see cref="UpsertAsync"/>. A check outside the lock has a window: the hook
+    /// saw "absent", an admin's first edit landed and created the record, and the identity upsert then
+    /// re-stamped it — <c>updatedBy</c> became the empty string, which is exactly the trail an admin
+    /// action is supposed to leave. Watched happening with the lock held by a test. Same lock, same
+    /// read, same write path as <see cref="UpsertAsync"/>: one <see cref="UnderGateAsync"/>, two
+    /// decisions.</para>
+    ///
+    /// <para>An unreadable record throws <see cref="MemberRecordUnavailableException"/> exactly as an
+    /// upsert does — a default written over a blocked developer's unreadable record is an unblock nobody
+    /// ordered.</para>
+    /// </summary>
+    public Task<UpsertResult> InsertIfAbsentAsync(string email, CancellationToken ct) =>
+        UnderGateAsync(email, ct, (current, normalized, now, path) =>
+        {
+            var (baseline, created) = Baseline(current, normalized, now, path);
+            return new WritePlan(baseline, created, Write: created);
+        });
+
+    /// <summary>What one guarded decision came to: the record to answer, whether it was created, and whether anything goes to disk.</summary>
+    private sealed record WritePlan(MemberRecord Record, bool Created, bool Write);
+
+    /// <summary>The decision made while the lock is held: from what is on disk now, to a <see cref="WritePlan"/>.</summary>
+    private delegate WritePlan Decide(MemberLookupResult current, string email, long now, string path);
+
+    /// <summary>
+    /// The one read-modify-write path: take the per-member gate, read the disk (never the cache — the
+    /// cache is what a concurrent writer makes stale), decide, write if the decision says so, invalidate.
+    /// The read is inside the lock on purpose, as <see cref="VaultStore.TryWriteVaultAsync"/>'s is:
+    /// outside it, the lost update is back.
+    /// </summary>
+    private async Task<UpsertResult> UnderGateAsync(string email, CancellationToken ct, Decide decide)
     {
         var normalized = MemberRecord.Normalize(email);
         var key = VaultStore.KeyFor(normalized);
@@ -251,15 +293,17 @@ public sealed class OrgMembersStore(string dataDir, ILogger<OrgMembersStore> log
         {
             var target = TargetFor(key, normalized);
             var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
-            var (baseline, created) = Baseline(ReadFromDisk(target), normalized, now, target.FilePath);
-            var edited = Stamp(edit(baseline), normalized, byAdmin, now);
-            Directory.CreateDirectory(_membersDir);
-            await VaultStore.AtomicWriteAsync(
-                target.FilePath,
-                JsonSerializer.SerializeToUtf8Bytes(edited, AppJsonContext.Default.MemberRecord),
-                ct);
-            _cache.TryRemove(key, out _);
-            return new UpsertResult(edited, created);
+            var plan = decide(ReadFromDisk(target), normalized, now, target.FilePath);
+            if (plan.Write)
+            {
+                Directory.CreateDirectory(_membersDir);
+                await VaultStore.AtomicWriteAsync(
+                    target.FilePath,
+                    JsonSerializer.SerializeToUtf8Bytes(plan.Record, AppJsonContext.Default.MemberRecord),
+                    ct);
+                _cache.TryRemove(key, out _);
+            }
+            return new UpsertResult(plan.Record, plan.Created);
         }
         finally
         {

--- a/src_minimalapi_server/src/Program.cs
+++ b/src_minimalapi_server/src/Program.cs
@@ -134,6 +134,19 @@ if (orgRecovery.Enabled)
         TimeSpan.FromHours(Math.Max(1, orgSetupTtlHours))));
 }
 
+// The members registry, the runtime settings and the event log — on EVERY deployment, because the
+// routes that read them exist on every deployment and answer "corp mode off" from the same code.
+// Nothing here may create their directories: each appears on its first write (OrgMembersStore says
+// why), and an `org/` on a personal server would tell an operator looking at the disk that this
+// server has a roster when it has none. Registered rather than constructed, unlike the stores above:
+// these take an ILogger<T>, and the logger factory exists only after Build().
+builder.Services.AddSingleton(sp => new OrgMembersStore(
+    dataDir, sp.GetRequiredService<ILoggerFactory>().CreateLogger<OrgMembersStore>()));
+builder.Services.AddSingleton(sp => new OrgSettingsStore(
+    dataDir, sp.GetRequiredService<ILoggerFactory>().CreateLogger<OrgSettingsStore>()));
+builder.Services.AddSingleton(sp => new OrgEventLog(
+    dataDir, sp.GetRequiredService<ILoggerFactory>().CreateLogger<OrgEventLog>(), () => DateTimeOffset.UtcNow));
+
 // Hard request-body ceiling (backstop; endpoints also check Content-Length).
 builder.WebHost.ConfigureKestrel(o => o.Limits.MaxRequestBodySize = maxVaultBytes + 64 * 1024);
 
@@ -303,13 +316,37 @@ var serverVersion = typeof(Program).Assembly
     .OfType<System.Reflection.AssemblyInformationalVersionAttribute>()
     .FirstOrDefault()?.InformationalVersion ?? typeof(Program).Assembly.GetName().Version?.ToString(3) ?? "unknown";
 
+// The corporate stores, resolved once the factory exists, and the one record the corporate routes
+// take. RequireCaller and DomainOf are local functions below and cross into OrgEndpoints.cs only as
+// delegates — the gates stay in this file, so it still answers "who may do this".
+var orgMembers = app.Services.GetRequiredService<OrgMembersStore>();
+var orgDeps = new OrgEndpointDeps(
+    RequireCaller,
+    DomainOf,
+    orgRecovery,
+    orgMembers,
+    app.Services.GetRequiredService<OrgSettingsStore>(),
+    app.Services.GetRequiredService<OrgEventLog>(),
+    allowAnyDomain,
+    log,
+    ContractVersion.Current);
+
 // The contract version, decided before authentication so a client too old to be served is told
 // THAT rather than being handed a 401 about a token that was never the problem. Every response
 // carries the server version, so a client learns it from a call it was already making.
+//
+// The minimum applied is the EFFECTIVE one: in corp mode it is floored at the contract from which
+// the role-and-policy document exists (3). A client below it does not know GET /api/org/me is
+// there, so on a server with a policy it obeys none of it, and serving it would hide that from
+// whoever deployed the server. Math.Max, so an operator's higher minimum stands; personal mode is
+// the configured value and nothing else, exactly as before.
+var effectiveMinimumContract = ContractVersion.MinimumFor(minimumClientContract, orgRecovery.Enabled);
+var corpFloorReason = orgRecovery.Enabled ? ContractVersion.CorpFloorReason : null;
 app.Use(async (ctx, next) =>
 {
     ctx.Response.Headers[ContractVersion.Header] = ContractVersion.Current.ToString();
-    var decision = ContractVersion.Judge(ctx.Request.Headers[ContractVersion.Header], minimumClientContract);
+    var decision = ContractVersion.Judge(
+        ctx.Request.Headers[ContractVersion.Header], effectiveMinimumContract, corpFloorReason);
     if (decision.Verdict == ContractVersion.Verdict.TooOld)
     {
         ctx.Response.StatusCode = StatusCodes.Status426UpgradeRequired;
@@ -626,6 +663,10 @@ app.MapPut("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     log.LogInformation("vault write by {Email} ({Bytes} bytes)", caller.Value.Email, ms.Length);
     metrics.VaultWritten(ms.Length);
     await store.RecordOwnerAsync(caller.Value.Email, ct);
+    // The registry's sibling of the sidecar above: corp mode only, idempotent, and it can never fail
+    // this response — the vault has already landed, and a 500 over a vault that was in fact stored is
+    // a worse failure than an unregistered person, whom the next sync registers anyway.
+    await OrgEndpoints.RegisterOnSyncAsync(orgDeps, caller.Value.Email, ct);
     ctx.Response.Headers.ETag = VaultStore.ETagFor(content);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;
 });
@@ -636,6 +677,10 @@ app.MapDelete("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     var caller = RequireCaller(ctx);
     if (caller is null) return;
     store.DeleteEverythingFor(caller.Value.Email);
+    // The registry record goes with the vault, so the registry cannot outgrow the people it describes.
+    // Not gated on corp mode: a record left behind by a roster since removed is still one to remove,
+    // and where no org/ exists this is one stat and nothing else.
+    await orgMembers.RemoveAsync(caller.Value.Email, ct);
     log.LogInformation("vault + inbox deleted for {Email}", caller.Value.Email);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;
 });
@@ -648,10 +693,30 @@ app.MapGet("/api/team", async (HttpContext ctx, CancellationToken ct) =>
     var callerDomain = DomainOf(caller.Value.Email);
     var members = store.ListVaultOwners()
         .Where(e => DomainOf(e) == callerDomain)
+        .Where(IsDiscoverable)
         .Select(e => new TeamMemberDto(e))
         .ToList();
     await ctx.Response.WriteAsJsonAsync(members, AppJsonContext.Default.ListTeamMemberDto);
 });
+
+// Filtered, not replaced. In corp mode a colleague whose record says `active: false` — blocked, the
+// behaviour epic 2 gives the field — is not offered as a recipient, and neither is one whose record
+// this build cannot read: the caller gate will refuse that person, so a share to them would wait in
+// an inbox nobody can open, and "unreadable" must never read as "fine" (the escalation the plan round
+// found). Personal mode consults nothing and stays byte-identical — the first clause short-circuits
+// before any lookup. The DTO is not widened here; the role and the projects join it in epic 3.
+bool IsDiscoverable(string email) =>
+    !orgRecovery.Enabled
+    || orgMembers.Find(email) switch
+    {
+        { Status: MemberLookup.Unavailable } => false,
+        { Status: MemberLookup.Found, Record: { Active: false } } => false,
+        _ => true,
+    };
+
+// The corporate surface, mapped from its own file — Program.cs is past the size ceiling and four
+// more epics add about twenty routes. The gates stay above; only routes live there.
+app.MapOrgEndpoints(orgDeps);
 
 // ----- corporate recovery: what every account here is subject to -----
 //

--- a/src_minimalapi_server/src/Program.cs
+++ b/src_minimalapi_server/src/Program.cs
@@ -666,6 +666,10 @@ app.MapPut("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     // The registry's sibling of the sidecar above: corp mode only, idempotent, and it can never fail
     // this response — the vault has already landed, and a 500 over a vault that was in fact stored is
     // a worse failure than an unregistered person, whom the next sync registers anyway.
+    //
+    // Inside it the record is written and THEN the member.registered row appended, so a crash between
+    // the two costs one row and never produces a duplicate: the row rides on `Created`, which
+    // UpsertAsync computes inside the per-member lock, and every later sync finds the record.
     await OrgEndpoints.RegisterOnSyncAsync(orgDeps, caller.Value.Email, ct);
     ctx.Response.Headers.ETag = VaultStore.ETagFor(content);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;
@@ -680,6 +684,11 @@ app.MapDelete("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     // The registry record goes with the vault, so the registry cannot outgrow the people it describes.
     // Not gated on corp mode: a record left behind by a roster since removed is still one to remove,
     // and where no org/ exists this is one stat and nothing else.
+    //
+    // Vault first, then the record — and the vault decides the response. RemoveAsync swallows a lock or
+    // a permission itself (logging at Error, naming the person), so a registry the OS will not let us
+    // touch cannot turn a delete that happened into a 500. The surviving state is a record with no
+    // vault: the admin list shows it, and the next DELETE or an admin removes it.
     await orgMembers.RemoveAsync(caller.Value.Email, ct);
     log.LogInformation("vault + inbox deleted for {Email}", caller.Value.Email);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;

--- a/src_minimalapi_server/src/Program.cs
+++ b/src_minimalapi_server/src/Program.cs
@@ -349,6 +349,16 @@ app.Use(async (ctx, next) =>
         ctx.Request.Headers[ContractVersion.Header], effectiveMinimumContract, corpFloorReason);
     if (decision.Verdict == ContractVersion.Verdict.TooOld)
     {
+        // The corporate surface promises a JSON {error} on every refusal, and this is the one refusal
+        // that runs before any of its endpoints: a contract-2 client asking for /api/org/me otherwise
+        // got a plain sentence the admin UI cannot parse, at the moment it needs to show why. Every
+        // older route keeps its plain text byte for byte — /api/org-recovery/* included, which shares
+        // a prefix and none of the shape; StartsWithSegments matches whole segments, so it stays out.
+        if (ctx.Request.Path.StartsWithSegments("/api/org"))
+        {
+            await OrgEndpoints.FailJson(ctx, StatusCodes.Status426UpgradeRequired, decision.Reason);
+            return;
+        }
         ctx.Response.StatusCode = StatusCodes.Status426UpgradeRequired;
         await ctx.Response.WriteAsync(decision.Reason);
         return;
@@ -668,8 +678,8 @@ app.MapPut("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     // a worse failure than an unregistered person, whom the next sync registers anyway.
     //
     // Inside it the record is written and THEN the member.registered row appended, so a crash between
-    // the two costs one row and never produces a duplicate: the row rides on `Created`, which
-    // UpsertAsync computes inside the per-member lock, and every later sync finds the record.
+    // the two costs one row and never produces a duplicate: the row rides on `Created`, which the
+    // store computes inside the per-member lock, and every later sync finds the record.
     await OrgEndpoints.RegisterOnSyncAsync(orgDeps, caller.Value.Email, ct);
     ctx.Response.Headers.ETag = VaultStore.ETagFor(content);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;
@@ -689,7 +699,12 @@ app.MapDelete("/api/vault", async (HttpContext ctx, CancellationToken ct) =>
     // a permission itself (logging at Error, naming the person), so a registry the OS will not let us
     // touch cannot turn a delete that happened into a 500. The surviving state is a record with no
     // vault: the admin list shows it, and the next DELETE or an admin removes it.
-    await orgMembers.RemoveAsync(caller.Value.Email, ct);
+    //
+    // CancellationToken.None on purpose. The vault is already gone, so the removal is owed whether or
+    // not the client is still listening: a disconnect that cancelled the wait would leave that record
+    // behind AND throw out of a handler whose work had already happened — watched, with the lock held
+    // by a test. What this makes uncancellable is one per-member lock held for a stat and an unlink.
+    await orgMembers.RemoveAsync(caller.Value.Email, CancellationToken.None);
     log.LogInformation("vault + inbox deleted for {Email}", caller.Value.Email);
     ctx.Response.StatusCode = StatusCodes.Status204NoContent;
 });

--- a/src_minimalapi_server/tests/AppJsonContextTests.cs
+++ b/src_minimalapi_server/tests/AppJsonContextTests.cs
@@ -1,0 +1,34 @@
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The source-generated JSON contract, checked structurally — because this is the one class of bug the
+/// endpoint suites cannot see.
+/// </summary>
+/// <remarks>
+/// <para><c>Program.cs</c> inserts <see cref="AppJsonContext"/> at the HEAD of the resolver chain, not
+/// alone in it. Under JIT a type the context does not know falls through to the reflection serializer:
+/// every request succeeds, every endpoint test stays green. The published Native AOT binary has no
+/// reflection serializer, so the same request fails at RUNTIME with "metadata not found" — on the
+/// release runner, or in production, never on a developer's machine. Asking the context directly is the
+/// only place the gap is visible before a publish.</para>
+/// </remarks>
+public sealed class AppJsonContextTests
+{
+    [Theory]
+    [InlineData(typeof(MemberSelfDto))]
+    [InlineData(typeof(ProjectSelfDto))]
+    [InlineData(typeof(PolicyDto))]
+    [InlineData(typeof(PendingFolderRemoval))]
+    [InlineData(typeof(ErrorDto))]
+    [InlineData(typeof(IReadOnlyList<ProjectSelfDto>))]
+    [InlineData(typeof(IReadOnlyList<PendingFolderRemoval>))]
+    public void EveryOrgResponseTypeIsInTheSourceGeneratedContext(Type type)
+    {
+        // Every DTO the org routes and their refusals serialize, lists included. A missing entry here is
+        // a 500 in the AOT binary and nothing at all in this suite's endpoint tests.
+        AppJsonContext.Default.GetTypeInfo(type).Should().NotBeNull(
+            $"{type.Name} crosses HTTP from /api/org/* and must be in AppJsonContext, or the AOT binary fails at runtime");
+    }
+}

--- a/src_minimalapi_server/tests/ContractVersionTests.cs
+++ b/src_minimalapi_server/tests/ContractVersionTests.cs
@@ -122,4 +122,76 @@ public sealed class ContractVersionTests
 
         response.StatusCode.Should().Be(HttpStatusCode.UpgradeRequired);
     }
+
+    // ---------------------------------------------------------------- the corp floor
+
+    [Fact]
+    public async Task CorpModeFloorsTheMinimumAtThreeEvenWithTheConfiguredDefault()
+    {
+        // Vault:MinimumClientContract is left at its default of 1. The roster alone raises the floor:
+        // a contract-2 client does not know /api/org/me exists, so on a server with a policy it would
+        // obey none of it — and nothing on either side would say so.
+        using var server = Corp.Server();
+        using var client = Claiming(server.ClientFor(Alice), "2");
+
+        var response = await client.GetAsync("/api/whoami", TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UpgradeRequired);
+    }
+
+    [Fact]
+    public async Task TheCorpRefusalNamesTheReason()
+    {
+        using var server = Corp.Server();
+        using var client = Claiming(server.ClientFor(Alice), "2");
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetAsync("/api/whoami", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UpgradeRequired);
+        var body = await response.Content.ReadAsStringAsync(ct);
+        body.Should().Contain("policy", "the sentence says WHY, not merely that the client is old");
+        body.Should().Contain("update the extension");
+    }
+
+    [Fact]
+    public async Task PersonalModeIsUnchanged()
+    {
+        // No roster, no floor: the configured minimum (1 by default) is the whole rule, exactly as
+        // before this build. A personal deployment must not notice the corporate surface exists.
+        using var server = new VaultServer();
+        var ct = TestContext.Current.CancellationToken;
+
+        using var two = Claiming(server.ClientFor(Alice), "2");
+        (await two.GetAsync("/api/whoami", ct)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var one = Claiming(server.ClientFor(Alice), "1");
+        (await one.GetAsync("/api/whoami", ct)).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ACorpServerServesAClientThatSpeaksThreeOrSaysNothing()
+    {
+        // The floor refuses what cannot read the policy. A current client can; a client that predates
+        // the whole mechanism sends nothing and is served as legacy here too — refusing it would turn
+        // the roster into an outage for every extension released before the header existed.
+        using var server = Corp.Server();
+        var ct = TestContext.Current.CancellationToken;
+
+        using var current = Claiming(server.ClientFor(Alice), "3");
+        (await current.GetAsync("/api/whoami", ct)).StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var silent = server.ClientFor(Alice);
+        (await silent.GetAsync("/api/whoami", ct)).StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public void TheFloorNeverLowersAHigherConfiguredMinimum()
+    {
+        // Math.Max, and a test because the natural slip is an assignment: an operator who set 5
+        // must not be handed 3 back by the roster.
+        ContractVersion.MinimumFor(configured: 5, corpMode: true).Should().Be(5);
+        ContractVersion.MinimumFor(configured: 1, corpMode: true).Should().Be(ContractVersion.OrgPolicyContract);
+        ContractVersion.MinimumFor(configured: 1, corpMode: false).Should().Be(1);
+    }
 }

--- a/src_minimalapi_server/tests/ContractVersionTests.cs
+++ b/src_minimalapi_server/tests/ContractVersionTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
 
 namespace CredVaultServer.Tests;
@@ -193,5 +194,50 @@ public sealed class ContractVersionTests
         ContractVersion.MinimumFor(configured: 5, corpMode: true).Should().Be(5);
         ContractVersion.MinimumFor(configured: 1, corpMode: true).Should().Be(ContractVersion.OrgPolicyContract);
         ContractVersion.MinimumFor(configured: 1, corpMode: false).Should().Be(1);
+    }
+
+    [Fact]
+    public void TheCorpReasonNamesTheFloorFromTheConstant()
+    {
+        // The sentence exists to name the floor; a number typed into it advertises a stale version the
+        // day the constant moves. Proved with teeth by moving the constant and watching this fail.
+        ContractVersion.CorpFloorReason.Should().Contain($"contract {ContractVersion.OrgPolicyContract}");
+    }
+
+    [Fact]
+    public async Task ATooOldClientOnACorporateRouteIsRefusedInJson()
+    {
+        // The middleware answers before any endpoint, so without this a contract-2 client asking for
+        // /api/org/me got the one plain-text refusal on a surface that promises {error} everywhere else —
+        // a body the admin UI cannot parse, at exactly the moment it needs to show why.
+        using var server = Corp.Server();
+        using var client = Claiming(server.ClientFor(Alice), "2");
+        var ct = TestContext.Current.CancellationToken;
+
+        var response = await client.GetAsync("/api/org/me", ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.UpgradeRequired);
+        response.Content.Headers.ContentType.Should().NotBeNull("a plain-text refusal carries no content type at all");
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+        var body = await response.Content.ReadAsStringAsync(ct);
+        JsonDocument.Parse(body).RootElement.GetProperty("error").GetString().Should().Contain("policy");
+    }
+
+    [Fact]
+    public async Task ATooOldClientOnAnOlderRouteIsStillRefusedInPlainText()
+    {
+        // The older routes' clients were written against a plain sentence, and keep it byte for byte —
+        // /api/org-recovery/* included: it shares a prefix with the corporate surface and none of its shape.
+        using var server = Corp.Server();
+        using var client = Claiming(server.ClientFor(Alice), "2");
+        var ct = TestContext.Current.CancellationToken;
+
+        foreach (var path in new[] { "/api/vault", "/api/org-recovery/config" })
+        {
+            var response = await client.GetAsync(path, ct);
+            response.StatusCode.Should().Be(HttpStatusCode.UpgradeRequired, path);
+            (response.Content.Headers.ContentType?.MediaType ?? "text/plain").Should().NotBe("application/json", path);
+            (await response.Content.ReadAsStringAsync(ct)).Should().StartWith("this server speaks contract", path);
+        }
     }
 }

--- a/src_minimalapi_server/tests/Corp.cs
+++ b/src_minimalapi_server/tests/Corp.cs
@@ -39,6 +39,40 @@ internal static class Corp
     public static MemberRecord ReadRecord(VaultServer server, string email) =>
         JsonSerializer.Deserialize(File.ReadAllBytes(RecordPath(server, email)), AppJsonContext.Default.MemberRecord)!;
 
+    /// <summary>
+    /// Make one record impossible to delete, the way the OS at hand refuses a delete. Windows refuses to
+    /// unlink a file another handle holds exclusively, so the handle is held — story 1's own trick for a
+    /// failing read. Unix unlinks an open file happily and refuses only when the DIRECTORY is not
+    /// writable, so the directory loses its write bit (CI runs as a non-root user; root ignores the bit).
+    /// Dispose undoes either, so the temp tree can still be removed.
+    /// </summary>
+    public static IDisposable Undeletable(string recordPath) =>
+        OperatingSystem.IsWindows()
+            ? new FileStream(recordPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)
+            : new WritableAgain(Path.GetDirectoryName(recordPath)!);
+
+    private sealed class WritableAgain : IDisposable
+    {
+        private readonly string _dir;
+
+        public WritableAgain(string dir)
+        {
+            _dir = dir;
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(_dir, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(_dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+    }
+
     /// <summary>Every row the event log holds, whatever day file it landed in. Empty when nothing was ever written.</summary>
     public static IReadOnlyList<OrgEventDto> EventRows(VaultServer server)
     {

--- a/src_minimalapi_server/tests/Corp.cs
+++ b/src_minimalapi_server/tests/Corp.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using FluentAssertions;
 
 namespace CredVaultServer.Tests;
 
@@ -70,6 +71,35 @@ internal static class Corp
             {
                 File.SetUnixFileMode(_dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
             }
+        }
+    }
+
+    /// <summary>
+    /// Poll until <paramref name="condition"/> holds, or fail naming what never happened. For the tests that
+    /// let a request run on after its client hung up: the server's continuation has no response to await,
+    /// so the disk is the only place to watch. Five seconds, ten-millisecond steps.
+    /// </summary>
+    public static async Task Eventually(Func<bool> condition, string what)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10, Ct);
+        }
+        condition().Should().BeTrue("within five seconds {0}", what);
+    }
+
+    /// <summary>
+    /// Wait until <paramref name="condition"/> holds or <paramref name="atMost"/> passes — and assert
+    /// nothing: for the moments a test must give an asynchronous abort time to land without being able
+    /// to say which way it will go.
+    /// </summary>
+    public static async Task Within(TimeSpan atMost, Func<bool> condition)
+    {
+        var deadline = DateTime.UtcNow + atMost;
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10, Ct);
         }
     }
 

--- a/src_minimalapi_server/tests/Corp.cs
+++ b/src_minimalapi_server/tests/Corp.cs
@@ -1,0 +1,58 @@
+using System.Text;
+using System.Text.Json;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// What every corporate-surface suite needs and none should spell out again: a server with a roster,
+/// the registry's on-disk layout, and a sync. Four suites reach for these; four private copies are how
+/// one of them ends up asserting against a path the store no longer writes.
+/// </summary>
+internal static class Corp
+{
+    /// <summary>Three officers, threshold two — the smallest roster the quorum guard accepts.</summary>
+    public const string Officers = "cto@example.com,lead@example.com,devops@example.com";
+
+    public const string Cto = "cto@example.com";
+
+    public static readonly byte[] Blob = Encoding.UTF8.GetBytes("""{"data":"ciphertext"}""");
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>A server in corp mode: a roster is configured, and that is the whole switch.</summary>
+    public static VaultServer Server() => new(new Dictionary<string, string?>
+    {
+        ["Vault__CorpRecovery__OfficerEmails"] = Officers,
+        ["Vault__CorpRecovery__Threshold"] = "2",
+    });
+
+    public static string OrgDir(VaultServer server) => Path.Combine(server.DataDir, "org");
+
+    /// <summary>The documented layout: <c>org/members/&lt;KeyFor(email)&gt;.json</c>.</summary>
+    public static string RecordPath(VaultServer server, string email) =>
+        Path.Combine(OrgDir(server), "members", VaultStore.KeyFor(email) + ".json");
+
+    /// <summary>The write that registers — a vault sync.</summary>
+    public static Task<HttpResponseMessage> SyncAsync(HttpClient client) =>
+        client.PutAsync("/api/vault", new ByteArrayContent(Blob), Ct);
+
+    public static MemberRecord ReadRecord(VaultServer server, string email) =>
+        JsonSerializer.Deserialize(File.ReadAllBytes(RecordPath(server, email)), AppJsonContext.Default.MemberRecord)!;
+
+    /// <summary>Every row the event log holds, whatever day file it landed in. Empty when nothing was ever written.</summary>
+    public static IReadOnlyList<OrgEventDto> EventRows(VaultServer server)
+    {
+        var dir = Path.Combine(OrgDir(server), "events");
+        if (!Directory.Exists(dir))
+        {
+            return [];
+        }
+        return
+        [
+            .. Directory.EnumerateFiles(dir, "*.ndjson")
+                .SelectMany(File.ReadAllLines)
+                .Where(line => line.Length > 0)
+                .Select(line => JsonSerializer.Deserialize(line, AppJsonContext.Default.OrgEventDto)!),
+        ];
+    }
+}

--- a/src_minimalapi_server/tests/OrgMeAuthorizationTests.cs
+++ b/src_minimalapi_server/tests/OrgMeAuthorizationTests.cs
@@ -1,0 +1,75 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// Who may read <c>GET /api/org/me</c>, and as whom. The gate is the shared <c>RequireCaller</c>; what is
+/// pinned here is the corporate surface's own promise on top of it — every refusal is a JSON
+/// <c>{error}</c> — and that the registry knows one person under one key however their token spells them.
+/// </summary>
+[Collection(ServerCollection.Name)]
+public sealed class OrgMeAuthorizationTests
+{
+    private static string Alice => $"alice@{VaultServer.Domain}";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static async Task<string> RefusalAsync(HttpResponseMessage response, HttpStatusCode expected)
+    {
+        response.StatusCode.Should().Be(expected);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json", "an admin UI has to show WHY");
+        var body = await response.Content.ReadAsStringAsync(Ct);
+        return JsonDocument.Parse(body).RootElement.GetProperty("error").GetString()!;
+    }
+
+    [Fact]
+    public async Task WithoutATokenOrgMeIs401WithAJsonBody()
+    {
+        using var server = Corp.Server();
+        using var anonymous = server.CreateClient();
+
+        var response = await anonymous.GetAsync("/api/org/me", Ct);
+
+        (await RefusalAsync(response, HttpStatusCode.Unauthorized)).Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task FromOutsideTheAllowedDomainOrgMeIs403WithAJsonBody()
+    {
+        // 403, not 401: the token is valid and the caller is simply not from a domain this deployment
+        // serves. RequireCaller refuses before the handler runs, so nothing here enrols an outsider.
+        using var server = Corp.Server();
+        using var mallory = server.ClientFor("mallory@outside.test");
+
+        var response = await mallory.GetAsync("/api/org/me", Ct);
+
+        (await RefusalAsync(response, HttpStatusCode.Forbidden)).Should().NotBeNullOrWhiteSpace();
+        Directory.Exists(Corp.OrgDir(server)).Should().BeFalse("a refused caller registers nothing");
+    }
+
+    [Fact]
+    public async Task AnEmailDifferingOnlyInCaseAndSpaceResolvesToTheSameRecord()
+    {
+        // The whole registry is keyed through VaultStore.KeyFor, which trims and lowercases — and the
+        // token's email is normalised before it ever reaches a handler. Proved end to end: a second
+        // record for "the same person, spelt differently" is how one colleague would get two roles.
+        using var server = Corp.Server();
+        using var shouted = server.ClientFor("  Alice@Example.COM  ");
+        using var alice = server.ClientFor(Alice);
+
+        (await Corp.SyncAsync(shouted)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await Corp.SyncAsync(alice)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        foreach (var client in new[] { shouted, alice })
+        {
+            var response = await client.GetAsync("/api/org/me", Ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            var me = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Ct)).RootElement;
+            me.GetProperty("email").GetString().Should().Be(Alice, "one spelling across the whole registry");
+        }
+        Directory.GetFiles(Path.Combine(Corp.OrgDir(server), "members")).Should().ContainSingle("one person, one record");
+        Corp.EventRows(server).Where(r => r.Kind == OrgEventKinds.MemberRegistered).Should().ContainSingle();
+    }
+}

--- a/src_minimalapi_server/tests/OrgMembersStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgMembersStoreTests.cs
@@ -384,4 +384,22 @@ public sealed class OrgMembersStoreTests : IDisposable
         _store.Find(Anna).Status.Should().Be(MemberLookup.NotRegistered);
         File.Exists(RecordPath(Anna)).Should().BeFalse();
     }
+
+    [Fact]
+    public async Task ARecordThatCannotBeDeletedIsLoggedAtErrorNamingTheEmail()
+    {
+        // DELETE /api/vault deletes the vault first and the record second, and the vault decides the
+        // response — so a refused delete here never surfaces to the caller. What survives is a record
+        // with no vault, listed by the admin list until the next DELETE or an admin removes it, and the
+        // operator's ONE signal about it is this line. It has to be at Error, and it has to say who.
+        await _store.UpsertAsync(Anna, r => r, Admin, Ct);
+
+        using (Corp.Undeletable(RecordPath(Anna)))
+        {
+            await _store.RemoveAsync(Anna, Ct);
+        }
+
+        File.Exists(RecordPath(Anna)).Should().BeTrue("the OS refused the delete, as arranged");
+        _log.Errors.Should().ContainSingle(m => m.Contains(Anna), "the operator's signal names the person");
+    }
 }

--- a/src_minimalapi_server/tests/OrgMembersStoreTests.cs
+++ b/src_minimalapi_server/tests/OrgMembersStoreTests.cs
@@ -402,4 +402,50 @@ public sealed class OrgMembersStoreTests : IDisposable
         File.Exists(RecordPath(Anna)).Should().BeTrue("the OS refused the delete, as arranged");
         _log.Errors.Should().ContainSingle(m => m.Contains(Anna), "the operator's signal names the person");
     }
+
+    // ---------------------------------------------------------------- insert-if-absent
+
+    [Fact]
+    public async Task InsertIfAbsentOverAnExistingRecordWritesNothing()
+    {
+        // The sync hook's write. An existing record comes back untouched — not re-stamped, not rewritten,
+        // not even its mtime — because a stamp is the trail an admin's action leaves, and a sync is not an
+        // admin's action.
+        await _store.UpsertAsync(Anna, r => r with { Role = MemberRole.Dev }, Admin, Ct);
+        var path = RecordPath(Anna);
+        var before = await File.ReadAllBytesAsync(path, Ct);
+        var mtime = File.GetLastWriteTimeUtc(path);
+
+        var result = await _store.InsertIfAbsentAsync(Anna, Ct);
+
+        result.Created.Should().BeFalse();
+        result.Record.UpdatedBy.Should().Be(Admin, "the existing record is what comes back");
+        result.Record.Role.Should().Be(MemberRole.Dev);
+        (await File.ReadAllBytesAsync(path, Ct)).Should().Equal(before, "not one byte moved");
+        File.GetLastWriteTimeUtc(path).Should().Be(mtime, "no write happened at all");
+    }
+
+    [Fact]
+    public async Task InsertIfAbsentCreatesTheDefaultAndSaysSo()
+    {
+        var result = await _store.InsertIfAbsentAsync(Anna, Ct);
+
+        result.Created.Should().BeTrue();
+        result.Record.Role.Should().Be(MemberRole.Default);
+        result.Record.UpdatedBy.Should().BeEmpty("the person registered themself");
+        _store.Find(Anna).Status.Should().Be(MemberLookup.Found);
+    }
+
+    [Fact]
+    public async Task InsertIfAbsentOverAnUnreadableRecordRefusesRatherThanOverwriting()
+    {
+        // The same rule as an upsert: a default written over a blocked developer's unreadable record is an
+        // unblock nobody ordered.
+        WriteRaw(Anna, "{ not json");
+
+        var act = () => _store.InsertIfAbsentAsync(Anna, Ct);
+
+        await act.Should().ThrowAsync<MemberRecordUnavailableException>();
+        (await File.ReadAllTextAsync(RecordPath(Anna), Ct)).Should().Be("{ not json");
+    }
 }

--- a/src_minimalapi_server/tests/OrgMembersTests.cs
+++ b/src_minimalapi_server/tests/OrgMembersTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// Registration, and the document every client reads: who gets written into the registry and when, and
+/// what <c>GET /api/org/me</c> answers before and after — on a corp server and on a personal one.
+/// </summary>
+/// <remarks>
+/// <para>The two rules under test pull in opposite directions and both have to hold: the first vault
+/// write registers a person, and reading <c>/api/org/me</c> registers nobody. Registering on read
+/// would fill an admin's list with every token that ever asked; not registering on write would leave
+/// the roster empty until an admin typed it in.</para>
+/// </remarks>
+[Collection(ServerCollection.Name)]
+public sealed class OrgMembersTests
+{
+    private static string Alice => $"alice@{VaultServer.Domain}";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static async Task<JsonElement> MeAsync(HttpClient client)
+    {
+        var response = await client.GetAsync("/api/org/me", Ct);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        return JsonDocument.Parse(await response.Content.ReadAsStringAsync(Ct)).RootElement;
+    }
+
+    [Fact]
+    public async Task RegistrationHappensOnTheFirstVaultWriteNotOnOrgMe()
+    {
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+
+        await MeAsync(alice);
+        File.Exists(Corp.RecordPath(server, Alice)).Should().BeFalse("reading the document registers nobody");
+
+        (await Corp.SyncAsync(alice)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        File.Exists(Corp.RecordPath(server, Alice)).Should().BeTrue("the first vault write is the registration");
+    }
+
+    [Fact]
+    public async Task TheDefaultRoleIsMember()
+    {
+        // A decision, not a fallback: defaulting to `dev` would strip every colleague of export and
+        // sharing on the day a roster appears, over a role nobody assigned them.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+
+        var me = await MeAsync(alice);
+
+        me.GetProperty("corpMode").GetBoolean().Should().BeTrue();
+        me.GetProperty("role").GetString().Should().Be(MemberRole.Member);
+        me.GetProperty("active").GetBoolean().Should().BeTrue();
+        me.GetProperty("policy").GetProperty("export").GetBoolean().Should().BeTrue();
+        Corp.ReadRecord(server, Alice).Role.Should().Be(MemberRole.Member, "the record on disk says the same");
+    }
+
+    [Fact]
+    public async Task ASecondVaultWriteDoesNotRewriteTheRecord()
+    {
+        // An admin set a role, and stamped the record doing it. The person's next sync must find the
+        // record and leave it alone — a sync that re-stamped it would say nobody changed the role, at
+        // the time of the sync, which is the one fact the admin list exists to show.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        var admin = new OrgMembersStore(server.DataDir, NullLogger<OrgMembersStore>.Instance);
+        var stamped = (await admin.UpsertAsync(Alice, r => r with { Role = MemberRole.Dev }, "admin@example.com", Ct)).Record;
+
+        (await Corp.SyncAsync(alice)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var after = Corp.ReadRecord(server, Alice);
+        after.UpdatedBy.Should().Be("admin@example.com", "the sync found a record and left it alone");
+        after.UpdatedAt.Should().Be(stamped.UpdatedAt);
+        after.Role.Should().Be(MemberRole.Dev);
+    }
+
+    [Fact]
+    public async Task PersonalModeCreatesNoOrgDirectory()
+    {
+        // The whole corporate surface is reachable on a personal server — the same endpoints answer
+        // "corp mode off" — and none of it may leave an `org/` behind: its presence is what tells an
+        // operator looking at the disk that this server has a roster.
+        using var server = new VaultServer();
+        using var alice = server.ClientFor(Alice);
+
+        await Corp.SyncAsync(alice);
+        await MeAsync(alice);
+        await alice.GetAsync("/api/team", Ct);
+        await alice.DeleteAsync("/api/vault", Ct);
+
+        Directory.Exists(Corp.OrgDir(server)).Should().BeFalse("a personal deployment has no roster, and no org/ that says otherwise");
+    }
+
+    [Fact]
+    public async Task OrgMeInPersonalModeAnswersCorpModeFalse()
+    {
+        // And the answer consults nothing. A record left over from a roster since removed — Alice as a
+        // blocked developer — must change no field: a personal server has to be indistinguishable from
+        // one that never had a registry, or "switch corp mode off" would not mean off.
+        using var server = new VaultServer();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        var leftover = new OrgMembersStore(server.DataDir, NullLogger<OrgMembersStore>.Instance);
+        await leftover.UpsertAsync(Alice, r => r with { Role = MemberRole.Dev, Active = false }, "admin@example.com", Ct);
+
+        var me = await MeAsync(alice);
+
+        me.GetProperty("corpMode").GetBoolean().Should().BeFalse();
+        me.GetProperty("email").GetString().Should().Be(Alice);
+        me.GetProperty("role").GetString().Should().Be(MemberRole.Member);
+        me.GetProperty("active").GetBoolean().Should().BeTrue();
+        me.GetProperty("isOfficer").GetBoolean().Should().BeFalse();
+        me.GetProperty("shareDefault").GetString().Should().Be(ShareDefaults.Default);
+        me.GetProperty("projects").GetArrayLength().Should().Be(0);
+        me.GetProperty("pendingFolderRemovals").GetArrayLength().Should().Be(0);
+        me.GetProperty("policy").GetProperty("export").GetBoolean().Should().BeTrue();
+        me.GetProperty("policy").GetProperty("share").GetString().Should().Be(ShareDefaults.Any);
+        me.GetProperty("policy").GetProperty("moveOutOfProject").GetBoolean().Should().BeTrue();
+        me.GetProperty("offlineLeaseHours").GetInt32().Should().Be(OrgSettingsDto.DefaultOfflineLeaseHours);
+        me.GetProperty("loginKeyVersion").GetInt32().Should().Be(0);
+        me.GetProperty("serverContract").GetInt32().Should().Be(ContractVersion.Current);
+    }
+
+    [Fact]
+    public async Task OrgMeForANeverSyncedCallerIsComputedAndWritesNothing()
+    {
+        // "Off is the shape, not a flag", applied to a person: the answer is correct before the disk
+        // agrees, and a token that stored nothing gets no file — not even the directory.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+
+        var me = await MeAsync(alice);
+
+        me.GetProperty("corpMode").GetBoolean().Should().BeTrue();
+        me.GetProperty("role").GetString().Should().Be(MemberRole.Member);
+        me.GetProperty("active").GetBoolean().Should().BeTrue();
+        me.GetProperty("offlineLeaseHours").GetInt32().Should().Be(OrgSettingsDto.DefaultOfflineLeaseHours);
+        Directory.Exists(Corp.OrgDir(server)).Should().BeFalse("a read created nothing");
+    }
+
+    [Fact]
+    public async Task AnOfficerReadsIsOfficerTrueWithoutARegistryRow()
+    {
+        // The roster is configuration, not a registry record; an officer who never synced is still
+        // one, and the client's admin predicate is `role === 'admin' || isOfficer`.
+        using var server = Corp.Server();
+        using var cto = server.ClientFor(Corp.Cto);
+
+        var me = await MeAsync(cto);
+
+        me.GetProperty("isOfficer").GetBoolean().Should().BeTrue();
+        me.GetProperty("role").GetString().Should().Be(MemberRole.Member, "the registry role is separate from the roster");
+    }
+}

--- a/src_minimalapi_server/tests/OrgRegistrationTests.cs
+++ b/src_minimalapi_server/tests/OrgRegistrationTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// The registration hook's failure semantics. It rides on a vault write that has ALREADY landed, so
+/// whatever goes wrong with the registry afterwards is the operator's problem and never the caller's:
+/// answering <c>500</c> for a vault that was in fact stored is a worse failure than an unregistered
+/// person, who is a state the design already handles.
+/// </summary>
+/// <remarks>
+/// The registry is broken here by making <c>org/members</c> a FILE — nothing under it can then be
+/// created or read, on any file system, without a permission trick the test runner may not have.
+/// </remarks>
+[Collection(ServerCollection.Name)]
+public sealed class OrgRegistrationTests
+{
+    private static string Alice => $"alice@{VaultServer.Domain}";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static string MembersPath(VaultServer server) => Path.Combine(Corp.OrgDir(server), "members");
+
+    private static void BlockTheRegistry(VaultServer server)
+    {
+        Directory.CreateDirectory(Corp.OrgDir(server));
+        File.WriteAllText(MembersPath(server), "a file where the store expects a directory");
+    }
+
+    [Fact]
+    public async Task AFailedRegistryWriteDoesNotFailTheVaultWrite()
+    {
+        using var server = Corp.Server();
+        BlockTheRegistry(server);
+        using var alice = server.ClientFor(Alice);
+
+        var put = await Corp.SyncAsync(alice);
+
+        put.StatusCode.Should().Be(
+            HttpStatusCode.NoContent,
+            "the vault was stored; a registry that cannot be written is logged, not reported to the caller");
+        (await alice.GetByteArrayAsync("/api/vault", Ct)).Should().Equal(Corp.Blob);
+        File.Exists(Corp.RecordPath(server, Alice)).Should().BeFalse("nothing could be written under a file");
+    }
+
+    [Fact]
+    public async Task TheNextVaultWriteRegistersThePersonAfterAll()
+    {
+        // Idempotent by design, so the retry is the next sync — no queue, no repair job.
+        using var server = Corp.Server();
+        BlockTheRegistry(server);
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        File.Exists(Corp.RecordPath(server, Alice)).Should().BeFalse("precondition: the first sync could not register");
+
+        File.Delete(MembersPath(server)); // the operator fixes the disk
+        var put = await Corp.SyncAsync(alice);
+
+        put.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        File.Exists(Corp.RecordPath(server, Alice)).Should().BeTrue("the next sync is the retry");
+        Corp.ReadRecord(server, Alice).Role.Should().Be(MemberRole.Member);
+    }
+
+    [Fact]
+    public async Task RegistrationLeavesExactlyOneMemberRegisteredRow()
+    {
+        // The row is emitted on the write that CREATES the record, and only on that one: a second sync
+        // finds the record and appends nothing, or the log would grow by one row per sync per person.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+
+        await Corp.SyncAsync(alice);
+        await Corp.SyncAsync(alice);
+
+        var registered = Corp.EventRows(server).Where(r => r.Kind == OrgEventKinds.MemberRegistered).ToList();
+        registered.Should().ContainSingle();
+        registered[0].Actor.Should().Be(Alice, "the person is the actor of their own registration");
+        registered[0].Subject.Should().Be(Alice);
+        registered[0].Detail.Should().Be(MemberRole.Member, "the row carries the default role");
+    }
+}

--- a/src_minimalapi_server/tests/OrgRegistrationTests.cs
+++ b/src_minimalapi_server/tests/OrgRegistrationTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Text.Json;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CredVaultServer.Tests;
@@ -11,12 +13,18 @@ namespace CredVaultServer.Tests;
 /// person, who is a state the design already handles.
 /// </summary>
 /// <remarks>
-/// The registry is broken here by making <c>org/members</c> a FILE — nothing under it can then be
-/// created or read, on any file system, without a permission trick the test runner may not have.
+/// <para>The registry is broken here by making <c>org/members</c> a FILE — nothing under it can then
+/// be created or read, on any file system, without a permission trick the test runner may not have.</para>
+/// <para>Two tests hold a lock the hook has to take, so that "a client hung up right here" and "an admin
+/// wrote right here" land in a window that is otherwise microseconds wide. The vault's per-member gate is
+/// static and process-wide, so every hold is released in a <c>finally</c>: a leaked gate would stall every
+/// later test in the same stripe.</para>
 /// </remarks>
 [Collection(ServerCollection.Name)]
 public sealed class OrgRegistrationTests
 {
+    private const string Admin = "admin@example.com";
+
     private static string Alice => $"alice@{VaultServer.Domain}";
 
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
@@ -27,6 +35,80 @@ public sealed class OrgRegistrationTests
     {
         Directory.CreateDirectory(Corp.OrgDir(server));
         File.WriteAllText(MembersPath(server), "a file where the store expects a directory");
+    }
+
+    private static int RegisteredRows(VaultServer server) =>
+        Corp.EventRows(server).Count(r => r.Kind == OrgEventKinds.MemberRegistered);
+
+    /// <summary>
+    /// The hook driven directly, no host: its dependencies on a throwaway directory, with a captured
+    /// logger — the server's own logger is Serilog's, and a promise about a log line would otherwise live
+    /// in a comment.
+    /// </summary>
+    private sealed class HookWorld : IDisposable
+    {
+        public string Dir { get; } = Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
+
+        public CapturingLogger<OrgEndpointDeps> Log { get; } = new();
+
+        public OrgEndpointDeps Deps { get; }
+
+        public HookWorld()
+        {
+            Directory.CreateDirectory(Dir);
+            Deps = new OrgEndpointDeps(
+                RequireCaller: _ => null,
+                DomainOf: _ => string.Empty,
+                OrgRecovery: OrgRecoveryConfig.Read(Corp.Officers.Split(','), 2),
+                Members: new OrgMembersStore(Dir, NullLogger<OrgMembersStore>.Instance),
+                Settings: new OrgSettingsStore(Dir, NullLogger<OrgSettingsStore>.Instance),
+                Events: new OrgEventLog(Dir, NullLogger<OrgEventLog>.Instance, () => DateTimeOffset.UtcNow),
+                AllowAnyDomain: false,
+                Log: Log,
+                ServerContract: ContractVersion.Current);
+        }
+
+        private string MembersDir => Path.Combine(Dir, "org", "members");
+
+        private string RecordPath(string email) => Path.Combine(MembersDir, VaultStore.KeyFor(email) + ".json");
+
+        public void BreakTheRegistry()
+        {
+            Directory.CreateDirectory(Path.Combine(Dir, "org"));
+            File.WriteAllText(MembersDir, "a file where the store expects a directory");
+        }
+
+        /// <summary>An admin's create, landing on disk directly — the store's own write would wait on the gate the test holds.</summary>
+        public void WriteRecordAsAdmin(string email)
+        {
+            Directory.CreateDirectory(MembersDir);
+            var record = MemberRecord.DefaultFor(email, DateTimeOffset.UtcNow.ToUnixTimeMilliseconds())
+                with { Role = MemberRole.Dev, UpdatedBy = Admin };
+            File.WriteAllBytes(RecordPath(email), JsonSerializer.SerializeToUtf8Bytes(record, AppJsonContext.Default.MemberRecord));
+        }
+
+        public MemberRecord ReadRecord(string email) =>
+            JsonSerializer.Deserialize(File.ReadAllBytes(RecordPath(email)), AppJsonContext.Default.MemberRecord)!;
+
+        public int RegisteredRows()
+        {
+            var events = Path.Combine(Dir, "org", "events");
+            return Directory.Exists(events)
+                ? Directory.EnumerateFiles(events, "*.ndjson").SelectMany(File.ReadAllLines).Count(l => l.Contains(OrgEventKinds.MemberRegistered))
+                : 0;
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Dir, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A handle not yet released; the temp sweeper gets it.
+            }
+        }
     }
 
     [Fact]
@@ -81,15 +163,12 @@ public sealed class OrgRegistrationTests
         registered[0].Detail.Should().Be(MemberRole.Member, "the row carries the default role");
     }
 
-    private static int RegisteredRows(VaultServer server) =>
-        Corp.EventRows(server).Count(r => r.Kind == OrgEventKinds.MemberRegistered);
-
     [Fact]
     public async Task ASecondSyncAfterRegistrationEmitsNothing()
     {
         // The testable half of the crash window. The record is written and THEN the row appended, so a
         // crash between the two costs one row and can never produce a duplicate: the row rides on
-        // `Created`, which UpsertAsync computes inside the lock, and a later sync finds the record.
+        // `Created`, which the store computes inside the lock, and a later sync finds the record.
         using var server = Corp.Server();
         using var alice = server.ClientFor(Alice);
         await Corp.SyncAsync(alice);
@@ -104,7 +183,7 @@ public sealed class OrgRegistrationTests
     public async Task TwoConcurrentFirstSyncsLeaveExactlyOneMemberRegisteredRow()
     {
         // Two devices of one person, both syncing for the first time: both see NotRegistered before
-        // either writes. The per-member lock inside UpsertAsync is what makes the second one report
+        // either writes. The per-member lock inside the store is what makes the second one report
         // Created: false — pinned here rather than trusted.
         using var server = Corp.Server();
         using var laptop = server.ClientFor(Alice);
@@ -118,36 +197,86 @@ public sealed class OrgRegistrationTests
     }
 
     [Fact]
-    public async Task AFailedRegistrationIsLoggedAtError()
+    public async Task AnAdminCreatingTheRecordInTheHooksWindowKeepsTheirStamp()
     {
-        // The swallow is deliberate, and this line is its one visible trace: an operator learns of an
-        // unregistered person from the log or not at all. Driven against the hook directly with a
-        // captured logger, because the server's own logger is Serilog's and the promise would otherwise
-        // live in a comment.
-        var dir = Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(Path.Combine(dir, "org"));
-        await File.WriteAllTextAsync(Path.Combine(dir, "org", "members"), "a file where the store expects a directory", Ct);
-        var log = new CapturingLogger<OrgEndpointDeps>();
-        var deps = new OrgEndpointDeps(
-            RequireCaller: _ => null,
-            DomainOf: _ => string.Empty,
-            OrgRecovery: OrgRecoveryConfig.Read(Corp.Officers.Split(','), 2),
-            Members: new OrgMembersStore(dir, NullLogger<OrgMembersStore>.Instance),
-            Settings: new OrgSettingsStore(dir, NullLogger<OrgSettingsStore>.Instance),
-            Events: new OrgEventLog(dir, NullLogger<OrgEventLog>.Instance, () => DateTimeOffset.UtcNow),
-            AllowAnyDomain: false,
-            Log: log,
-            ServerContract: ContractVersion.Current);
+        // The window: the hook decides "no record" and only then takes the per-member lock. An admin whose
+        // first edit lands in between creates the record — and a sync that then re-stamped it would write
+        // updatedBy "" over the admin's name, which is exactly the trail an admin action is supposed to
+        // leave. The gate is held here so the hook's decision is forced BEFORE the admin's write and its
+        // own write AFTER it: RegisterOnSyncAsync runs synchronously up to its first wait on that gate.
+        using var world = new HookWorld();
+        var gate = VaultStore.GateFor(VaultStore.KeyFor(Alice));
+        Task hook;
+        await gate.WaitAsync(Ct);
         try
         {
-            var act = () => OrgEndpoints.RegisterOnSyncAsync(deps, Alice, Ct);
-
-            await act.Should().NotThrowAsync("the vault write this rides on has already landed");
-            log.Errors.Should().ContainSingle(m => m.Contains(Alice), "the operator's signal names the person");
+            hook = OrgEndpoints.RegisterOnSyncAsync(world.Deps, Alice, Ct);
+            world.WriteRecordAsAdmin(Alice);
         }
         finally
         {
-            Directory.Delete(dir, recursive: true);
+            gate.Release();
         }
+        await hook;
+
+        var record = world.ReadRecord(Alice);
+        record.UpdatedBy.Should().Be(Admin, "the sync found a record the moment it held the lock, and left it alone");
+        record.Role.Should().Be(MemberRole.Dev);
+        world.RegisteredRows().Should().Be(0, "the sync created nothing, so it registered nobody");
+        world.Log.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task AClientHangingUpAfterRegistrationStillGetsItsRow()
+    {
+        // Once the record is written the row is owed whoever is still listening: cancelled by a
+        // disconnect, it is lost for good, because every later sync finds the record and emits nothing.
+        // The event log's writer lock is held here so the hang-up lands exactly between the two.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        var events = server.Services.GetRequiredService<OrgEventLog>();
+        using var hangUp = new CancellationTokenSource();
+        Task<HttpResponseMessage> sync;
+        await events.Gate.WaitAsync(Ct);
+        try
+        {
+            sync = alice.PutAsync("/api/vault", new ByteArrayContent(Corp.Blob), hangUp.Token);
+            await Corp.Eventually(
+                () => File.Exists(Corp.RecordPath(server, Alice)),
+                "the record was written and the hook reached the event log");
+            hangUp.Cancel();
+            // The abort lands off the calling thread. A hook that handed the client's token to the append
+            // abandons the row and the request completes here; one that did not is still waiting on the
+            // gate. Half a second either way, so the release cannot beat the cancellation and prove nothing.
+            await Corp.Within(TimeSpan.FromMilliseconds(500), () => sync.IsCompleted);
+        }
+        finally
+        {
+            events.Gate.Release();
+        }
+        try
+        {
+            await sync;
+        }
+        catch (OperationCanceledException)
+        {
+            // The client hung up, as arranged.
+        }
+
+        await Corp.Eventually(() => RegisteredRows(server) == 1, "the member.registered row was appended after the client left");
+    }
+
+    [Fact]
+    public async Task AFailedRegistrationIsLoggedAtError()
+    {
+        // The swallow is deliberate, and this line is its one visible trace: an operator learns of an
+        // unregistered person from the log or not at all.
+        using var world = new HookWorld();
+        world.BreakTheRegistry();
+
+        var act = () => OrgEndpoints.RegisterOnSyncAsync(world.Deps, Alice, Ct);
+
+        await act.Should().NotThrowAsync("the vault write this rides on has already landed");
+        world.Log.Errors.Should().ContainSingle(m => m.Contains(Alice), "the operator's signal names the person");
     }
 }

--- a/src_minimalapi_server/tests/OrgRegistrationTests.cs
+++ b/src_minimalapi_server/tests/OrgRegistrationTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace CredVaultServer.Tests;
 
@@ -78,5 +79,75 @@ public sealed class OrgRegistrationTests
         registered[0].Actor.Should().Be(Alice, "the person is the actor of their own registration");
         registered[0].Subject.Should().Be(Alice);
         registered[0].Detail.Should().Be(MemberRole.Member, "the row carries the default role");
+    }
+
+    private static int RegisteredRows(VaultServer server) =>
+        Corp.EventRows(server).Count(r => r.Kind == OrgEventKinds.MemberRegistered);
+
+    [Fact]
+    public async Task ASecondSyncAfterRegistrationEmitsNothing()
+    {
+        // The testable half of the crash window. The record is written and THEN the row appended, so a
+        // crash between the two costs one row and can never produce a duplicate: the row rides on
+        // `Created`, which UpsertAsync computes inside the lock, and a later sync finds the record.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        RegisteredRows(server).Should().Be(1, "precondition: the first sync registered");
+
+        await Corp.SyncAsync(alice);
+
+        RegisteredRows(server).Should().Be(1, "a sync that finds a record appends nothing");
+    }
+
+    [Fact]
+    public async Task TwoConcurrentFirstSyncsLeaveExactlyOneMemberRegisteredRow()
+    {
+        // Two devices of one person, both syncing for the first time: both see NotRegistered before
+        // either writes. The per-member lock inside UpsertAsync is what makes the second one report
+        // Created: false — pinned here rather than trusted.
+        using var server = Corp.Server();
+        using var laptop = server.ClientFor(Alice);
+        using var desktop = server.ClientFor(Alice);
+
+        var results = await Task.WhenAll(Corp.SyncAsync(laptop), Corp.SyncAsync(desktop));
+
+        results.Should().OnlyContain(r => r.StatusCode == HttpStatusCode.NoContent);
+        RegisteredRows(server).Should().Be(1);
+        Directory.GetFiles(Path.Combine(Corp.OrgDir(server), "members")).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task AFailedRegistrationIsLoggedAtError()
+    {
+        // The swallow is deliberate, and this line is its one visible trace: an operator learns of an
+        // unregistered person from the log or not at all. Driven against the hook directly with a
+        // captured logger, because the server's own logger is Serilog's and the promise would otherwise
+        // live in a comment.
+        var dir = Path.Combine(Path.GetTempPath(), "cred-vault-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(dir, "org"));
+        await File.WriteAllTextAsync(Path.Combine(dir, "org", "members"), "a file where the store expects a directory", Ct);
+        var log = new CapturingLogger<OrgEndpointDeps>();
+        var deps = new OrgEndpointDeps(
+            RequireCaller: _ => null,
+            DomainOf: _ => string.Empty,
+            OrgRecovery: OrgRecoveryConfig.Read(Corp.Officers.Split(','), 2),
+            Members: new OrgMembersStore(dir, NullLogger<OrgMembersStore>.Instance),
+            Settings: new OrgSettingsStore(dir, NullLogger<OrgSettingsStore>.Instance),
+            Events: new OrgEventLog(dir, NullLogger<OrgEventLog>.Instance, () => DateTimeOffset.UtcNow),
+            AllowAnyDomain: false,
+            Log: log,
+            ServerContract: ContractVersion.Current);
+        try
+        {
+            var act = () => OrgEndpoints.RegisterOnSyncAsync(deps, Alice, Ct);
+
+            await act.Should().NotThrowAsync("the vault write this rides on has already landed");
+            log.Errors.Should().ContainSingle(m => m.Contains(Alice), "the operator's signal names the person");
+        }
+        finally
+        {
+            Directory.Delete(dir, recursive: true);
+        }
     }
 }

--- a/src_minimalapi_server/tests/OrgUnavailableTests.cs
+++ b/src_minimalapi_server/tests/OrgUnavailableTests.cs
@@ -1,0 +1,68 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// A record this build cannot read, met on the request path. The plan round's finding: "unparseable
+/// means not registered" is a privilege escalation with a corrupted file as its trigger — not
+/// registered means the default, the default is <c>member</c>, and a member may export. So the endpoint
+/// fails CLOSED, and this suite is what keeps it there.
+/// </summary>
+[Collection(ServerCollection.Name)]
+public sealed class OrgUnavailableTests
+{
+    private const string Garbage = "{ this is not a record";
+
+    private static string Alice => $"alice@{VaultServer.Domain}";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    /// Overwrite Alice's record with something no build can parse — a half-written file, a bad sector, a
+    /// restore from a truncated archive — and move its mtime on, as the seconds between a restore and
+    /// the next request would, so the server's stat check cannot mistake it for the record it cached.
+    /// </summary>
+    private static async Task CorruptAsync(VaultServer server, string email)
+    {
+        var path = Corp.RecordPath(server, email);
+        await File.WriteAllTextAsync(path, Garbage, Ct);
+        File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+    }
+
+    [Fact]
+    public async Task ACorruptedRecordMakesOrgMeAnswer503NeverTheMemberDefault()
+    {
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        await CorruptAsync(server, Alice);
+
+        var response = await alice.GetAsync("/api/org/me", Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        response.Headers.RetryAfter.Should().NotBeNull("the client is told when to ask again");
+        response.Content.Headers.ContentType!.MediaType.Should().Be("application/json");
+        var body = await response.Content.ReadAsStringAsync(Ct);
+        body.Should().NotContain("\"role\"", "the member default is the escalation this status exists to prevent");
+        JsonDocument.Parse(body).RootElement.GetProperty("error").GetString().Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task ASyncNeverOverwritesARecordItCannotRead()
+    {
+        // The hook's idempotent write starts from the default when it finds no record. A default written
+        // over an unreadable one is an unblock nobody ordered — so the corrupt bytes stay, the vault
+        // write still lands, and the operator fixes the file.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        await CorruptAsync(server, Alice);
+
+        var put = await Corp.SyncAsync(alice);
+
+        put.StatusCode.Should().Be(HttpStatusCode.NoContent, "the vault write is not the registry's hostage");
+        (await File.ReadAllTextAsync(Corp.RecordPath(server, Alice), Ct)).Should().Be(Garbage);
+    }
+}

--- a/src_minimalapi_server/tests/OrgUnavailableTests.cs
+++ b/src_minimalapi_server/tests/OrgUnavailableTests.cs
@@ -65,4 +65,23 @@ public sealed class OrgUnavailableTests
         put.StatusCode.Should().Be(HttpStatusCode.NoContent, "the vault write is not the registry's hostage");
         (await File.ReadAllTextAsync(Corp.RecordPath(server, Alice), Ct)).Should().Be(Garbage);
     }
+
+    [Fact]
+    public async Task TheUnavailableBodySaysAnAdministratorMustRepairIt()
+    {
+        // "Cannot be read" alone leaves a person retrying into the same wall. The body names who can end
+        // it — an administrator — and still not the file: the path is the operator's business and is in
+        // the server log, written once by the store.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await Corp.SyncAsync(alice);
+        await CorruptAsync(server, Alice);
+
+        var response = await alice.GetAsync("/api/org/me", Ct);
+
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
+        var error = JsonDocument.Parse(await response.Content.ReadAsStringAsync(Ct)).RootElement.GetProperty("error").GetString()!;
+        error.Should().Contain("administrator", "the person is told who can end this");
+        error.Should().NotContain("org/members", "the file stays in the log");
+    }
 }

--- a/src_minimalapi_server/tests/TeamCorpTests.cs
+++ b/src_minimalapi_server/tests/TeamCorpTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace CredVaultServer.Tests;
+
+/// <summary>
+/// <c>/api/team</c> on a corp server: filtered, not replaced. A colleague whose record says
+/// <c>active: false</c> cannot be picked as a recipient; everything else about the answer — the DTO
+/// most of all — is exactly what it was, because epic 3 owns the wider shape and two plans describing
+/// one change is how neither builds it.
+/// </summary>
+[Collection(ServerCollection.Name)]
+public sealed class TeamCorpTests
+{
+    private static string Alice => $"alice@{VaultServer.Domain}";
+
+    private static string Bob => $"bob@{VaultServer.Domain}";
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>What epic 2's block will do, done by hand: the record says inactive.</summary>
+    private static Task BlockAsync(VaultServer server, string email) =>
+        new OrgMembersStore(server.DataDir, NullLogger<OrgMembersStore>.Instance)
+            .UpsertAsync(email, r => r with { Active = false }, "admin@example.com", Ct);
+
+    private static async Task<string> TeamSeenByAliceAfterBothSyncedAndBobWasBlocked(VaultServer server)
+    {
+        using var alice = server.ClientFor(Alice);
+        using var bob = server.ClientFor(Bob);
+        await Corp.SyncAsync(alice);
+        await Corp.SyncAsync(bob);
+        await BlockAsync(server, Bob);
+        return await alice.GetStringAsync("/api/team", Ct);
+    }
+
+    [Fact]
+    public async Task AnInactiveMemberIsAbsentInCorpModeAndPresentInPersonalMode()
+    {
+        using (var corp = Corp.Server())
+        {
+            var team = await TeamSeenByAliceAfterBothSyncedAndBobWasBlocked(corp);
+            team.Should().Contain(Alice).And.NotContain(Bob, "a blocked colleague cannot be offered as a recipient");
+        }
+
+        using (var personal = new VaultServer())
+        {
+            // The same record on disk, written by the test — the server never would — and ignored:
+            // personal mode consults no registry, whatever a leftover file says.
+            var team = await TeamSeenByAliceAfterBothSyncedAndBobWasBlocked(personal);
+            team.Should().Contain(Alice).And.Contain(Bob, "personal mode has no registry to consult");
+        }
+    }
+
+    [Fact]
+    public async Task TheTeamShapeIsUnchangedForAnOldClient()
+    {
+        // An old client sends no contract header and is served as legacy — on a corp server too. What it
+        // gets must be the shape it was written against: an array of {email} and no other field, and the
+        // very same bytes a personal server answers for the same owners.
+        string corp;
+        using (var server = Corp.Server())
+        {
+            using var alice = server.ClientFor(Alice);
+            await Corp.SyncAsync(alice);
+            var response = await alice.GetAsync("/api/team", Ct);
+            response.StatusCode.Should().Be(HttpStatusCode.OK);
+            corp = await response.Content.ReadAsStringAsync(Ct);
+        }
+
+        string personal;
+        using (var server = new VaultServer())
+        {
+            using var alice = server.ClientFor(Alice);
+            await Corp.SyncAsync(alice);
+            personal = await alice.GetStringAsync("/api/team", Ct);
+        }
+
+        corp.Should().Be(personal, "byte-identical: the filter changes who is listed, never how");
+        var members = JsonDocument.Parse(corp).RootElement;
+        members.GetArrayLength().Should().Be(1);
+        members[0].EnumerateObject().Select(p => p.Name).Should().Equal("email");
+        members[0].GetProperty("email").GetString().Should().Be(Alice);
+    }
+}

--- a/src_minimalapi_server/tests/VaultTests.cs
+++ b/src_minimalapi_server/tests/VaultTests.cs
@@ -162,4 +162,50 @@ public sealed class VaultTests
         (await alice.GetAsync("/api/vault", ct)).StatusCode.Should().Be(HttpStatusCode.NotFound);
         File.Exists(record).Should().BeTrue("the surviving state: a record with no vault");
     }
+
+    [Fact]
+    public async Task AClientHangingUpDuringTheDeleteDoesNotAbandonTheRegistryRemoval()
+    {
+        // The vault is gone the moment DeleteEverythingFor returns; the registry removal after it is owed
+        // whether or not anyone is still listening. Cancelled by a disconnect it would leave a record
+        // with no vault AND throw out of a handler whose work had already happened. The per-member lock
+        // the removal waits on is held here so the hang-up lands exactly in that window; the gate is
+        // process-wide, hence the finally.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        var ct = TestContext.Current.CancellationToken;
+        await alice.PutAsync("/api/vault", new ByteArrayContent(Blob), ct);
+        var record = Corp.RecordPath(server, Alice);
+        var vault = Path.Combine(server.DataDir, "vaults", VaultStore.KeyFor(Alice) + ".bin");
+        var gate = VaultStore.GateFor(VaultStore.KeyFor(Alice));
+        using var hangUp = new CancellationTokenSource();
+        Task<HttpResponseMessage> delete;
+        await gate.WaitAsync(ct);
+        try
+        {
+            delete = alice.DeleteAsync("/api/vault", hangUp.Token);
+            await Corp.Eventually(() => !File.Exists(vault), "the handler deleted the vault and reached the registry");
+            hangUp.Cancel();
+            // The test host raises RequestAborted off the calling thread and completes the client's task
+            // only when the pipeline ends. A handler that honoured the token dies here and that task
+            // completes; one that ignores it is still waiting on the gate, so the task cannot be awaited
+            // before the release without a deadlock. Half a second is given for the abort to land either
+            // way — releasing sooner would hand the gate to a waiter not yet cancelled and prove nothing.
+            await Corp.Within(TimeSpan.FromMilliseconds(500), () => delete.IsCompleted);
+        }
+        finally
+        {
+            gate.Release();
+        }
+        try
+        {
+            await delete;
+        }
+        catch (OperationCanceledException)
+        {
+            // The client hung up, as arranged.
+        }
+
+        await Corp.Eventually(() => !File.Exists(record), "the registry record was removed after the client left");
+    }
 }

--- a/src_minimalapi_server/tests/VaultTests.cs
+++ b/src_minimalapi_server/tests/VaultTests.cs
@@ -122,4 +122,21 @@ public sealed class VaultTests
         var afterwards = await alice.GetAsync("/api/vault", TestContext.Current.CancellationToken);
         afterwards.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
+
+    [Fact]
+    public async Task DeletingAVaultRemovesTheRegistryRecord()
+    {
+        // The registry cannot outgrow the people it describes: a person leaves by being blocked, and a
+        // record is deleted only with their vault. Without this the growth budget is a sentence in a plan.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        await alice.PutAsync("/api/vault", new ByteArrayContent(Blob), TestContext.Current.CancellationToken);
+        var record = Corp.RecordPath(server, Alice);
+        File.Exists(record).Should().BeTrue("precondition: the write registered the caller");
+
+        var deleted = await alice.DeleteAsync("/api/vault", TestContext.Current.CancellationToken);
+
+        deleted.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        File.Exists(record).Should().BeFalse("the record goes with the vault");
+    }
 }

--- a/src_minimalapi_server/tests/VaultTests.cs
+++ b/src_minimalapi_server/tests/VaultTests.cs
@@ -139,4 +139,27 @@ public sealed class VaultTests
         deleted.StatusCode.Should().Be(HttpStatusCode.NoContent);
         File.Exists(record).Should().BeFalse("the record goes with the vault");
     }
+
+    [Fact]
+    public async Task AFailedRegistryRemovalDoesNotFailTheVaultDelete()
+    {
+        // Vault first, then the record, and the vault decides the response. A record the OS will not
+        // let go of leaves a record with no vault behind — the admin list shows it, the next DELETE or an
+        // admin removes it — which is a better state than a 500 for a delete that in fact happened.
+        using var server = Corp.Server();
+        using var alice = server.ClientFor(Alice);
+        var ct = TestContext.Current.CancellationToken;
+        await alice.PutAsync("/api/vault", new ByteArrayContent(Blob), ct);
+        var record = Corp.RecordPath(server, Alice);
+
+        HttpResponseMessage deleted;
+        using (Corp.Undeletable(record))
+        {
+            deleted = await alice.DeleteAsync("/api/vault", ct);
+        }
+
+        deleted.StatusCode.Should().Be(HttpStatusCode.NoContent, "the vault half happened and is what the caller asked for");
+        (await alice.GetAsync("/api/vault", ct)).StatusCode.Should().Be(HttpStatusCode.NotFound);
+        File.Exists(record).Should().BeTrue("the surviving state: a record with no vault");
+    }
 }

--- a/src_vs_code/src/contractVersion.ts
+++ b/src_vs_code/src/contractVersion.ts
@@ -16,7 +16,19 @@
  */
 
 /** What this build speaks. Bump when the extension can no longer read an older server. */
-export const CLIENT_CONTRACT_VERSION = 2;
+export const CLIENT_CONTRACT_VERSION = 3;
+
+/**
+ * The first contract that serves the role-and-policy document, `GET /api/org/me`.
+ *
+ * <p>On a server with a corporate roster this is also the FLOOR: a client below it is refused with
+ * 426, because it does not know the document exists and would obey none of it — exporting, sharing
+ * and backing up exactly as before, with nothing on either side saying so. That is why this
+ * constant moves in the same change as the server's, not a story later: a gap between the two is a
+ * window in which this repository's own extension is refused by its own server. Below this version
+ * a server has no roles to report, and the extension shows none.</p>
+ */
+export const ORG_POLICY_CONTRACT = 3;
 
 /**
  * The first contract that carries a share's `format` through `/api/shares`.


### PR DESCRIPTION
## What changed, and why

Story 2 of epic 1 (`todo/PLAN_corp_registry_roles.md`), and the first corporate route on the wire.
Story 1 landed the three stores with no HTTP at all; this makes the server register people and lets a
client read what it is.

**`GET /api/org/me`** is the one document a client fetches each sync cycle — role, flags, the derived
policy, the offline lease. It answers three ways, and the third is the point: a caller with no record
gets the computed default and **no file is written**, because a token that synced nothing must not
create a row in an admin's list; a record this build cannot read answers **`503`**, never the member
default, since not registered means the default, the default is `member`, and a member may export;
and a server with no roster answers `corpMode:false`, indistinguishable from one that never heard of
any of this.

**Registration rides on the vault write** — corp mode only, and it can never fail that response: the
vault has already landed, and a `500` over a vault that was in fact stored is worse than an
unregistered person, whom the next sync registers. `/api/team` drops inactive members in corp mode
while personal mode stays byte-identical, and deleting a vault takes its registry record with it.

**Contract 3, as a floor rather than a rewrite:** `Math.Max(configured, 3)` in corp mode, so an
operator's higher minimum still stands and personal mode is the configured value and nothing else.
The `426` names why — a pre-3 client does not know the policy document exists, so on a server with a
policy it obeys none of it. The extension's constant moves in the same commit, because the constant
IS the cutover; splitting them would open a window in which this repository's own extension is
refused by its own server.

## Evidence

- [x] **Red-green**, and two of the reds had to be built twice — both mistakes are recorded in the
      code rather than quietly fixed:
      - The plan's literal registration hook re-stamped the record: an identity upsert still stamps,
        so a sync after an admin's edit reset the admin's name — `Expected after.UpdatedBy to be
        "admin@example.com" … but "" has a length of 0`.
      - The nine `/api/org/me` tests began at `404`, the contract-floor tests at `200` where `426`
        belonged, and the team filter listed the blocked colleague by name.
      - The cancellation test first **passed against the unfixed code**, because the host raises the
        abort off the calling thread and the gate was released before it arrived; the second attempt
        **deadlocked the fixed code** by waiting on a client task the pipeline completes only after
        the gate it was waiting for. The final shape polls briefly, then releases.
      - The insert-if-absent race is driven deterministically: the test holds the per-member gate,
        lets the hook run to its first wait — its "absent" decision already made — writes the admin's
        record, then releases.
- [x] **All the tests ran:**

```
dotnet build dew_flow_creds_for_devs.slnx -c Debug
  Build succeeded. 0 Warning(s) 0 Error(s)

./src_minimalapi_server/tests/bin/Debug/net10.0/CredVaultServer.Tests.exe
  total: 252   failed: 0   succeeded: 252   skipped: 0        (207 on main before this branch)

cd src_vs_code && npm test        →  3195 pass, 0 fail, 4 skipped
cd http && node scripts/http-run.mjs   →  64 requests, 117 checks, 0 failed, exit 0
node .claude/rules/shared/tools/plan-lifecycle.mjs   →  clean
node .claude/rules/shared/tools/pin-check.mjs        →  OK
```

## Documentation

- [x] `research/module_server.md`: the route and what it is (a document the client obeys, not a
      boundary), the registration hook, the team filter, the delete, the corp contract floor, the JSON
      refusal on the corporate surface, and the test count.
- [x] `http/org/me.http` — the happy flow asserting the shape, the officer flag, `401`/`403` as JSON,
      a real `426` from a contract-2 client, and an `@uncovered` line for the `503` the wire cannot
      provoke. `http/httpyac.config.js`'s own pin moved to `contract: '3'` — which no plan had
      noticed: the suite runs against a corp-mode server, so without it every request in the tree
      would answer `426`.
- [ ] No plan is finished yet; epic 1 has two more stories, so nothing is promoted out of `todo/`.

## The reviewer

Both gates ran on this story's own branch, and both are folded in.

- **Plan round**: twelve findings, six accepted, six rejected with reasons. One accepted finding
  turned out to be half wrong once in the code, and the test is what said so — a failing registry
  removal could not produce a `500`, because the store already caught it; what was missing was the
  signal, and that half was red for real.
- **Code round** (nine reviewers): twenty-one findings, seven accepted, fourteen rejected. Three of
  the rejections are worth knowing: two reviewers reported defects from the first of the two commits
  under review, both already fixed in the second, and one reported a missing `using` directive in a
  file whose first line is exactly that — a claim the build refutes, since warnings are errors here.
  The rest were sized for ten thousand people where the plan budgets two hundred, with the threshold
  at which they become right recorded in the plan.

The seven accepted: a JSON `426` on the corporate surface (it was plain text while every other
refusal there is `ErrorDto`), the registration hook's check-then-write window closed by moving the
decision inside the lock, a client disconnect no longer turning a completed vault delete into a
`500`, the same disconnect no longer losing an audit row that was already owed, a `503` body that
says an administrator must repair it, and a refusal sentence built from the contract constant instead
of spelling the number.

**One code-scanning alert was dismissed rather than fixed**, with the reason recorded on the alert:
CodeQL flags the operator log naming a person, and that log line exists because a review finding
asked for it — a refused record must name whose it is and which file held it. The server already
keeps an `.email` sidecar per account in plaintext and has logged the caller on every vault write and
delete since before this change, so nothing new is exposed.

## Release / deploy

- [x] No release needed. The server's version is untouched and nothing here ships in either half's
      artefact; the extension changes two constants and no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
