### PR TITLE
chore(deps): stop proposing @types/vscode minor bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,13 +36,19 @@ updates:
     # The toolchain is chosen by hand with the VS Code engine version: a major bump of TypeScript or
     # of @types/node is a decision, not an update — the first two the bot proposed (5.9 -> 7.0,
     # 20 -> 26) both failed typecheck on arrival, 2026-09-05.
+    #
+    # @types/vscode is ignored for MINOR bumps too, not only major. vsce refuses to package when the
+    # types are newer than engines.vscode ("@types/vscode ^1.136.0 greater than engines.vscode
+    # ^1.85.0"), so 1.134 -> 1.136 is a red build, and the only ways out are to raise engines — which
+    # drops every user below that VS Code build, a product decision — or to leave the types alone.
+    # PR #37, 2026-09-07.
     ignore:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/vscode"
-        update-types: ["version-update:semver-major"]
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
     labels: ["dependencies", "npm"]
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
Dependabot proposes `@types/vscode` 1.134.0 → 1.136.0 inside the weekly npm group every Monday, and it fails `typecheck · test · package` every time — not in typecheck, in the **Package** step:

```
@types/vscode ^1.136.0 greater than engines.vscode ^1.85.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

`vsce` refuses to package an extension whose VS Code types run ahead of the engine it declares. That is a real check, not a flake, and it has exactly two resolutions:

- **raise `engines.vscode`** — which drops every user on a VS Code older than that build. A product decision with its own review, not a dependency update;
- **leave the types where the engine is** — free.

The `ignore` list already held `@types/vscode` for majors, on the reasoning written above it for TypeScript and `@types/node`: the toolchain is chosen by hand with the VS Code engine version. Minor bumps belong in the same sentence — the packaging check does not care which half of the version moved, only that the types are ahead of the engine.

PR #37 is closed as part of this — it cannot go green as proposed. The sibling change in `dew_flow_connect_other_ais` (#79) is the same sentence; both extensions declare `^1.85.0`.

## Test plan

- [x] The file parses as YAML
- [x] No source, manifest or workflow touched — only the bot's proposal policy
- [ ] Next Monday's run no longer proposes an `@types/vscode` minor bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Прочее**
  * Обновлены правила автоматического управления зависимостями: минорные обновления типов VS Code теперь также игнорируются, чтобы избежать проблем со сборкой расширения.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->