### PR TITLE
chore(release): extension 1.2.0

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -4,6 +4,52 @@ All notable changes to **CredsForDevs** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] — projects, an event log you can read, and a locked vault that offers to unlock
+
+### Added
+
+- **Projects (corporate epic 3).** An admin creates, assigns and removes projects from the tree, and
+  a Team row says which project a person is on. The assigned developer's project folder appears in
+  their own vault at the next sync, follows the project's name, is locked for them, and is removed
+  on instruction. A developer's share carries and binds its project, so the client stops offering
+  shares that could not be accepted.
+- **An event-log tab (corporate epic 4).** *Event Log…* on a corporate account row answers who
+  shared what: newest first, four groups to narrow by, and Load more. The server had recorded and
+  served the log for two stories; this is the half a person can read. An admin sees every row, and
+  so does a recovery officer.
+- **Generate API key**, beside Generate password and Generate passphrase. Deliberately not the
+  password generator with the length turned up, and it takes no options — length and character
+  classes are ignored, because the value is meant to be pasted rather than typed.
+
+### Fixed
+
+- **A locked vault was offered a PIN change instead of an unlock.** The auto-sync notification
+  showed both buttons unconditionally, with *Set Sync PIN* FIRST — including for a vault whose PIN
+  was already stored and which had merely auto-locked. That button is not a label: it re-wraps the
+  vault under a new PIN and writes it to the sync location, so every other machine stops opening the
+  file until the same PIN is typed there. A five-minute idle timer proposed a fleet-wide credential
+  rotation as its fix, while the readiness icon had answered *Unlock* for the same state all along.
+  Now a stored PIN is offered only the unlock; the PIN offer survives where it is genuinely the fix
+  (no PIN stored at all) and is never the first button. A keychain that cannot answer counts as
+  "a PIN is stored", because a failed lookup is no evidence that none is — and the safe side of that
+  guess is the one that does not rewrite a vault.
+- **A bearer token could be sent to a git host.** `isServerLocation` accepts anything `http(s)://`,
+  which `https://git.example.com/team/vault.git` passes — so a vault synced over git could be handed
+  a corporate client that sends `Authorization: Bearer <token>` to a git remote. The question is
+  asked once now, by `isCorpServerLocation`.
+- **A failed share removal read as success.** `removeShare` discarded the server's answer, so a 500
+  left the share in the inbox with nothing recorded, after the secret had already been imported.
+- **A cancelled prune lost the record of what it had already deleted**, so no later sweep could
+  retry those shares. It now stops early and hands back what it did.
+- **The event tab kept the OLDEST rows and dropped the newest** when trimming, a "no log here" answer
+  outlived the question that caused it, and a *more* with no cursor re-fetched the first page and
+  appended it to itself. A request in flight is no longer drawn into a closed tab.
+- **The vault is pulled before any project folder is reconciled**, and a folder that was kept is
+  adopted rather than duplicated — two machines seeding one assignment offline no longer mint two.
+- The event page takes its colours from `--vscode-*` alone; the literal fallbacks were copied from
+  another page and were wrong on a contrast theme.
+- A code-scanning alert: the page test's script-tag scan reads either spelling of the tag.
+
 ## [1.1.0] — the help speaks five languages, and one payment mark instead of nine
 
 ### Fixed

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Your coding agent can run the migration — and can never be handed the password. SSH hosts, keys, databases, VPNs, secrets and config files in VS Code, with optional end-to-end encrypted team sync.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
## What this is

The version bump and CHANGELOG section for **CredsForDevs 1.2.0**. Nothing else — no code.

**Minor, not patch:** sixteen extension commits have landed since `extension-v1.1.0`, and three
of them are features (projects, the event-log tab, Generate API key), so the version says so.

## What 1.2.0 ships

**Added** — corporate epic 3 (projects created, assigned and removed from the tree; the project
folder appearing in the assigned person's own vault, following its name, locked for a developer,
removed on instruction; a share that carries and binds its project); epic 4's reader (the Event Log
tab — newest first, four groups, Load more, open to an admin and to a recovery officer); the
Generate API key button.

**Fixed** — the locked-vault notification (a vault whose Sync PIN is stored is offered only the
unlock; the button that re-keys the vault for every machine is no longer first, and a keychain that
cannot answer counts as "a PIN is stored"); a bearer token that could reach a git host; a failed
share removal that read as success; a cancelled prune that lost the record of what it had deleted;
an event tab that trimmed the newest rows instead of the oldest; a code-scanning alert about a
script-tag scan that read only one spelling.

## Verification

Run before the tag, and all of it rather than only what is near the change:

- extension — **3585 tests, 0 failures, 0 cancelled**, 4 skipped (pre-existing)
- server — **549 tests, 0 failures**
- `dotnet build dew_flow_creds_for_devs.slnx` — **0 warnings, 0 errors**
- `npm run lint`, `npm run typecheck` — clean
- the release workflow's **own** CHANGELOG slicer was executed over the new section rather than
  read: it returns exactly `## [1.2.0] …` and does not bleed into `## [1.1.0]`

## Review gate

Not applicable, and said rather than left silent: this branch changes a version string and a
markdown section. There is no behaviour to review — every code change in it was gated on its own
branch before it reached `main`.

## After the merge

The tag `extension-v1.2.0` is cut on `main`, which is what actually publishes the `.vsix`; a merge
publishes nothing on its own. The packaged artefact will be checked from the release itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
