### PR TITLE
chore(release): extension 1.3.0 — the share PIN draws itself, and epic 5's half of the window

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -4,9 +4,24 @@ All notable changes to **CredsForDevs** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] — the share PIN draws itself, and an encrypted archive of the whole server
 
 ### Added
+
+- **A share PIN you no longer have to invent.** The *One-time share PIN* box has two buttons now:
+  one draws a six-word passphrase and copies it, ready to paste into whatever chat you tell the
+  recipient in, and one unmasks it for reading aloud. When the share lands, the message offers
+  **Copy again** and **Show PIN**.
+
+  A passphrase rather than a password because the job is not entropy but travel: it crosses a chat,
+  it may be spoken, and the recipient types it back. On a vault server that PIN is the ENTIRE
+  secret — a share is sealed under the recipient's address plus the PIN, and the address is
+  public — so the weakest link was a person inventing one under time pressure.
+
+  Edit what was drawn and it becomes a PIN of your own, confirmed twice like any other. The PIN
+  never appears in the notification text: a notification is kept until it is dismissed, so
+  **Show PIN** is a modal, which is not. And the value is copied again when the share actually
+  lands, so the 45-second promise is counted from the moment you go and paste it.
 
 - **Server Backup (corporate epic 5).** *Server Backup…* on the account row of an admin — or of a
   recovery officer, who administers unconditionally — takes one encrypted archive of everything a
@@ -27,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Restoring is `deploy/restore-archive.sh` on the host: it asks for the same words, and checks
   everything it can — the archive verifies, the key opens it, the tree extracts — before the stack is
   stopped or a byte of current data is moved.
+
+### Fixed
+
+- **Copying the same secret twice in a row cut its clipboard window short.** Every copy scheduled
+  its own wipe and none of them cancelled the one before, so a second copy of the SAME value left
+  the earlier timer running — and it still found its own string on the clipboard and cleared it at
+  the earlier deadline. The clipboard emptied before the notice said it would. A copy now cancels
+  the wipe it supersedes.
 
 ## [1.2.0] — projects, an event log you can read, and a locked vault that offers to unlock
 

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Your coding agent can run the migration — and can never be handed the password. SSH hosts, keys, databases, VPNs, secrets and config files in VS Code, with optional end-to-end encrypted team sync.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
Cuts `extension-v1.3.0`. Version bump and CHANGELOG only — no code changes.

## What this release ships

Sixteen extension commits have landed since `extension-v1.2.0`, and two of them are features, so this is a minor rather than a patch.

**The share PIN can be generated.** The *One-time share PIN* box gains a button that draws a six-word passphrase and copies it — ready to paste into whatever chat the recipient is told in — and one that unmasks it for reading aloud. On a vault server that PIN is the **entire** secret: a share is sealed under the recipient's address plus the PIN, and the address is public. A person inventing one under time pressure was the weakest link in the product.

**Epic 5's extension half**, already sitting in `[Unreleased]` and untouched by this commit: *Server Backup* on an admin's account row, the backup key shown once, and the per-destination status that separates "the upload arrived" from "the retention pass could then run".

**One real `Fixed`.** Every secret copy scheduled its own clipboard wipe and none of them cancelled the one before, so a second copy of the *same* value left the earlier timer running — and it still found its own string and cleared the clipboard at the earlier deadline. That affected every copy site since the TTL existed, not only the new one.

## Verified rather than assumed

- The **CHANGELOG slicer the release workflow itself uses** was run over the new section: it returns exactly `[1.3.0]` and does not bleed into `[1.2.0]`.
- `npm run package` builds `creds-for-devs-1.3.0.vsix` (63 files, 887 KB).
- The six strings the feature is made of are **present in `dist/extension.js`** — the artefact carries what the source claims, which a passing test suite does not prove.
- 3683 tests pass, lint and typecheck clean.

## After merge

Push `extension-v1.3.0`; `release.yml` builds the `.vsix`, checks the tag against the manifest version, and publishes with this CHANGELOG section as the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Новые возможности**
  * Добавлена возможность автоматически генерировать одноразовый PIN-код для обмена.
  * Добавлено резервное копирование всего сервера.

* **Исправления**
  * Исправлен таймер очистки буфера обмена при повторном копировании одного и того же секрета.

* **Обновления**
  * Версия расширения VS Code обновлена до 1.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->