### PR TITLE
chore(release): extension 1.3.0 — the server backs itself up, and an admin can watch it

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **CredsForDevs** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] — the server backs itself up, and an admin can watch it
 
 ### Added
 

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Your coding agent can run the migration — and can never be handed the password. SSH hosts, keys, databases, VPNs, secrets and config files in VS Code, with optional end-to-end encrypted team sync.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
The version bump that ships epic 5. `1.2.0` was tagged thirteen minutes before
[#41](https://github.com/oleksandrdubyna88/dew_flow_creds_for_devs/pull/41) merged, so Server Backup
missed it entirely — the `[Unreleased]` section added there becomes `[1.3.0]` here, and the manifest
follows.

**The server needs no file change.** Its version comes from the tag itself — `${GITHUB_REF_NAME#server-v}`,
used as the image tag, the Docker build arg and `-p:Version=` — so `server-v0.6.0` is a tag on this
commit and nothing more. That is the larger of the two releases: **46 server commits** since
`server-v0.5.3`, which was cut before epics 3, 4 and 5.

## Verified before the tag, not after

| | |
|---|---|
| Server tests | 763 |
| Extension tests | 3679 |
| Broker · CLI · MCP | 29 · 78 · 40 |
| eslint · size ratchet | clean · at baseline |
| `plan-lifecycle` | clean |
| Printable-key vectors | match the generator, and round-trip through the shipped parser |
| `backup-archive-itest` | 27 of 27, against the real binary |
| `restore-archive-itest` | 32 of 32, with `docker` shimmed |

## And the artefact, not the source

`npm run package` produces `creds-for-devs-1.3.0.vsix`. Its **embedded** manifest carries version
`1.3.0`, the `credSshManager.orgBackup` command and its `account-corpAdmin || account-corpOfficer`
`when` clause; its bundle contains the backup routes and the tab's own strings. Checked by reading
the zip rather than by trusting the build.

## Still open, and named rather than implied

The **live restore rehearsal** — an archive taken from a running server and restored onto an empty
stack — has not been run. It is a tracked exception recorded in `research/module_deployment.md`,
`research/module_tests.md` and the plan. The sensible order is to deploy the server release first and
rehearse against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)