### PR TITLE
chore(rules): bump the shared-rules pin, and bound this repository's builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -47,3 +47,10 @@ jobs:
       # paste was measured — v2 against v5 — so it is the one that most needs the check.
       - name: Gate snippet
         run: node .claude/rules/shared/tools/gate-snippet-check.mjs
+
+      # The root Directory.Build.rsp is really there and really says -nr:false. Measured on this
+      # family's machine: five sessions building at once held 72 MSBuild workers and 10.7 GB,
+      # because a worker busy in one build cannot be reused by another
+      # (see .claude/rules/shared/csharp/dotnet-build.md). A repository with no C# passes without an opinion.
+      - name: Build flags
+        run: node .claude/rules/shared/tools/build-flags-check.mjs

--- a/Directory.Build.rsp
+++ b/Directory.Build.rsp
@@ -1,0 +1,1 @@
+-nr:false


### PR DESCRIPTION
`pin-check` runs in this repository's CI and compares the **committed** pin with the rules remote's tip, so every open pull request here went red the moment `dew_flow_conventions` merged [#21](https://github.com/oleksandrdubyna88/dew_flow_conventions/pull/21). This is the bump.

The pin moves to `d7cfbca`, which adds `csharp/dotnet-build.md` and the two checks behind it.

## Why the response file arrives in the same commit as the check

Measured 2026-09-11 on the machine this family runs on — 24 CPUs, 44 GB, five autonomous sessions building in parallel: **72 MSBuild worker processes holding 10 775 MB**. A worker busy in one build cannot be reused by another, so every *concurrent* build opens its own pool and the total ratchets to the high-water mark. Three builds run sequentially retained 0 new workers; the same three run concurrently retained 14.

`-nr:false` in a root `Directory.Build.rsp` is the half a file can hold — it takes what a build leaves behind from **11 workers / 1222 MB to zero**. The other half, `-m:N`, cannot live in a file at all: `dotnet build` injects its own `-maxcpucount` and the command line beats the response file. That half is enforced by a `PreToolUse` hook in the rules repository, and the rule says plainly where that hook does and does not reach.

Landing the file and the CI step together is deliberate: the step is green the day it arrives instead of red until somebody follows up.

## Verified

The mechanism was verified end to end in `dew_flow_mcp` on this same SDK, attributing workers by creation time inside the build window: without the file 2 retained, with it **0**, with it plus `-m:4` a peak of **3** instead of 11. Here, `pin-check` is green after the commit rather than before it — it reads the committed pin — and `build-flags-check` reports OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
