### PR TITLE
fix(broker): the socket listener is behind a door it can never pass

### DIFF
--- a/research/PLAN_broker_origin_guard.md
+++ b/research/PLAN_broker_origin_guard.md
@@ -145,3 +145,24 @@ bridge and the pipe — passes its functional checks, as do `agent-broker-itest`
 - **Two WSL integration checks fail on this machine** — `no half of the bridge outlives the client`
   and `disposing the manager takes it down` — both naming installed WSL binaries and both failing the
   same way with this change stashed. Reported as pre-existing rather than claimed unrelated.
+
+
+## The regression it caused, and the fix
+
+**The `Host` check was applied to a listener that has no host.** Both of the broker's listeners share
+one router, and the door was wrapped around the router — so the unix socket (a named pipe on Windows)
+got the port's door. A caller reaching the broker over that socket was never told a port: the WSL
+bridge and Remote-SSH forward a socket *because* no loopback port is reachable. The URL it composes
+therefore cannot name our port, and `creds ssh <name>` over the socket started answering `403`.
+
+`NOT_ON_THE_NETWORK` is now that listener's facing, and `doorsFor` builds one wrapper per listener
+(sharing the once-per-window note). The `Host` check is skipped there; the browser-header checks are
+not. This is not a weakening: `Host` exists to close DNS rebinding, which is a browser attack, and no
+page can open a unix socket or a named pipe. The socket's guard is its file mode — 0600 on POSIX —
+and the grant token, exactly as before this plan.
+
+**Why it reached `main`.** The only thing exercising the path was one case in `creds-cli-itest.cjs`,
+guarded by `process.platform !== 'win32'`, so it could not run on the machine the change was written
+on. There are unit tests now: `brokerOrigin.test.ts` decides the headers for both facings, and
+`brokerOriginDoor.test.ts` drives the real second listener end to end on **both** platforms — the
+first unit test that has ever opened it.

--- a/research/PLAN_broker_origin_guard.md
+++ b/research/PLAN_broker_origin_guard.md
@@ -158,8 +158,15 @@ therefore cannot name our port, and `creds ssh <name>` over the socket started a
 `NOT_ON_THE_NETWORK` is now that listener's facing, and `doorsFor` builds one wrapper per listener
 (sharing the once-per-window note). The `Host` check is skipped there; the browser-header checks are
 not. This is not a weakening: `Host` exists to close DNS rebinding, which is a browser attack, and no
-page can open a unix socket or a named pipe. The socket's guard is its file mode — 0600 on POSIX —
-and the grant token, exactly as before this plan.
+page can open a unix socket or a named pipe.
+
+The socket's guard is its file mode — 0600 on POSIX, which refuses another user before any of our
+code runs; on Windows the pipe takes the default DACL and is a convenience rather than a boundary.
+Behind the transport, each route authorises exactly as it does on the port, because they share one
+router: the token door needs a grant token, the **alias door needs none** (its authorisation is the
+rate limit and the consent modal, and it mints its own grant), and the **read routes authenticate
+nothing** — which is precisely why the browser-header checks stay on this listener. Nothing here
+changed; a precondition that could never hold was removed.
 
 **Why it reached `main`.** The only thing exercising the path was one case in `creds-cli-itest.cjs`,
 guarded by `process.platform !== 'win32'`, so it could not run on the machine the change was written

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -1911,10 +1911,24 @@ rebinding**: the browser sends the name the page was loaded from, which is the a
 port it connected to, so both must name this listener exactly. `Sec-Fetch-Site` refuses every value
 but `none`; its *absence* admits, because no command-line client sends fetch metadata at all.
 
-`behindTheDoor` wraps the handler both listeners are given, so "every listener is covered" is true by
+`doorsFor` builds a wrapper per listener around one router, so "every listener is covered" is true by
 construction rather than by every listener happening to route through one method. A refusal is `403`
 with a sentence, sets `Connection: close` (the body was never read), and is said to the person **once
-per window**. Record: [PLAN_broker_origin_guard.md](PLAN_broker_origin_guard.md).
+per window** — once across both doors, which is why they are built together rather than separately.
+
+**There are two doors because only one listener has a port**, and getting that wrong shipped. The
+second listener is a unix socket (a named pipe on Windows) — what Remote-SSH forwards and what the
+WSL bridge relays into — and it shared the port's door, so it inherited the `Host` check. A caller
+reaching the broker that way was never told a port, so the URL it composes cannot name ours, and
+every call by NAME over the socket answered `403`. `NOT_ON_THE_NETWORK` is that listener's facing:
+the `Host` check is skipped, the browser-header checks are not. Not a hole — `Host` exists to stop
+DNS rebinding, that is a browser attack, and no page can open a socket or a pipe; what guards this
+transport is the file mode (0600 on POSIX) and the grant token, as before.
+
+It reached `main` because the only thing exercising the path was a POSIX-only case in the CLI
+integration suite. `brokerOriginDoor.test.ts` now drives the real second listener on **both**
+platforms, which is also the first unit test that ever opened it. Record:
+[PLAN_broker_origin_guard.md](PLAN_broker_origin_guard.md).
 
 **A signed envelope without its signature is tampered, not legacy** (`verifyEnvelopeMac`,
 `requireIntactEnvelope`). The envelope MAC exists for one threat, named where it is computed: on a

--- a/research/module_extension.md
+++ b/research/module_extension.md
@@ -1922,8 +1922,18 @@ WSL bridge relays into — and it shared the port's door, so it inherited the `H
 reaching the broker that way was never told a port, so the URL it composes cannot name ours, and
 every call by NAME over the socket answered `403`. `NOT_ON_THE_NETWORK` is that listener's facing:
 the `Host` check is skipped, the browser-header checks are not. Not a hole — `Host` exists to stop
-DNS rebinding, that is a browser attack, and no page can open a socket or a pipe; what guards this
-transport is the file mode (0600 on POSIX) and the grant token, as before.
+DNS rebinding, that is a browser attack, and no page can open a socket or a pipe.
+
+**What guards that transport is worth stating exactly, because "the token" is not the whole answer**
+and the two listeners share one router, so every route's own authorisation is the same on both.
+The TRANSPORT is guarded by the operating system: mode 0600 on POSIX, so another user is refused
+before a byte of ours runs — the one real boundary the loopback port never had. On Windows the pipe
+takes the default DACL, which `brokerListeners.ts` documents as a convenience rather than a
+boundary. Behind that, each route authorises as it always did: the token door requires a grant
+token; the **alias door requires none** — its authorisation is `AliasThrottle` plus the consent
+modal, and it mints its own grant — and the **read routes authenticate nothing**, which is why the
+browser-header checks stay on this listener even though no browser can reach it. This change moved
+none of that; it removed a precondition that could never hold.
 
 It reached `main` because the only thing exercising the path was a POSIX-only case in the CLI
 integration suite. `brokerOriginDoor.test.ts` now drives the real second listener on **both**

--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -6,6 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A `creds` call over the forwarded socket works again.** The browser guard added in the previous
+  change checks that `Host` names this window's own loopback address and port — and the broker's
+  second listener has no port to name. That listener is a unix socket (a named pipe on Windows),
+  which is what Remote-SSH forwards and what the WSL bridge relays into: a caller reaching the
+  broker that way was never told a port, so the URL it composes cannot match, and every call by
+  NAME over the socket was refused with 403.
+
+  The check is skipped on that listener, which is not a hole: `Host` exists to stop DNS rebinding,
+  that is a browser attack, and no page can open a unix socket or a named pipe. The browser-header
+  checks still apply there, and the port listener is unchanged. What guards the socket is its file
+  mode — 0600 on POSIX — and the grant token, as before.
+
+  It reached `main` because the only thing exercising that path was a POSIX-only case in the CLI
+  integration suite. There are unit tests now, driving the real second listener on both platforms.
+
 ### Security
 
 - **The agent broker now refuses requests that look like they came from a browser.** It is a loopback

--- a/src_vs_code/src/brokerOrigin.ts
+++ b/src_vs_code/src/brokerOrigin.ts
@@ -33,25 +33,57 @@ import { errorBody, statusForErrorCode } from './brokerProtocol';
  * construction rather than by every listener happening to route through one method. Both the
  * loopback port and the pipe are handed this.</p>
  *
- * <p>`note` is called at most once per window: the first browser-shaped request is worth telling a
- * person about, and the thousandth would flood the journal that exists to show what an AGENT did.</p>
+ * <p>Two of them are built, by `doorsFor` below: the port's door checks `Host`, the socket's cannot
+ * (see {@link NOT_ON_THE_NETWORK}). They share one `note`, so a person is told once per window and
+ * not once per listener.</p>
  */
 export function behindTheDoor(
   handle: (req: IncomingMessage, res: ServerResponse) => void,
-  at: () => Loopback,
+  at: () => DoorFacing,
   respond: (res: ServerResponse, status: number, body: unknown) => void,
-  note: (message: string) => void,
-): (req: IncomingMessage, res: ServerResponse) => void {
-  let said = false;
+  note: () => void,
+): Served {
   return (req, res) => {
     if (!turnAwayAtTheDoor(req.headers, at(), (status, body) => respond(res, status, body), res)) {
       handle(req, res);
       return;
     }
+    note();
+  };
+}
+
+/** A node request handler — the shape both listeners take. */
+export type Served = (req: IncomingMessage, res: ServerResponse) => void;
+
+/** One router, two listeners, two doors — because only one of them has a port. */
+export interface Doors {
+  readonly onThePort: Served;
+  readonly onTheSocket: Served;
+}
+
+/**
+ * Both doors onto one router.
+ *
+ * <p>Built together so the note is said at most ONCE per window rather than once per listener: the
+ * first browser-shaped request is worth telling a person about, and the thousandth would flood the
+ * journal that exists to show what an agent did.</p>
+ */
+export function doorsFor(
+  handle: Served,
+  port: () => number,
+  respond: (res: ServerResponse, status: number, body: unknown) => void,
+  note: (message: string) => void,
+): Doors {
+  let said = false;
+  const once = (): void => {
     if (!said) {
       said = true;
       note(REFUSAL_NOTE);
     }
+  };
+  return {
+    onThePort: behindTheDoor(handle, () => ({ port: port() }), respond, once),
+    onTheSocket: behindTheDoor(handle, () => NOT_ON_THE_NETWORK, respond, once),
   };
 }
 
@@ -71,7 +103,7 @@ const REFUSAL_NOTE =
  */
 export function turnAwayAtTheDoor(
   headers: IncomingHttpHeaders,
-  at: Loopback,
+  at: DoorFacing,
   respond: (status: number, body: unknown) => void,
   res: { setHeader(name: string, value: string): void },
 ): boolean {
@@ -89,6 +121,25 @@ export interface Loopback {
   readonly port: number;
 }
 
+/**
+ * The listener a browser cannot reach at all: a Unix socket on POSIX, a named pipe on Windows.
+ *
+ * <p>Both listeners share one handler, so this one inherited the `Host` check — and there is no
+ * `Host` it can pass. A caller that reaches the broker this way was never told a port (that is the
+ * point: the WSL bridge and Remote-SSH forward a socket precisely because no loopback port is
+ * reachable), so the URL it composes cannot name the one we are listening on. It broke the alias
+ * call over the socket, which is the bridge's whole reason for existing.</p>
+ *
+ * <p>Skipping the check here is not a hole, because `Host` does exactly one job: it stops DNS
+ * rebinding. That is a browser attack, and no page can open a Unix socket or a named pipe. What
+ * guards this transport is the file mode — 0600 on POSIX — and the grant token, as before. The
+ * browser-header checks still apply, because they cost nothing.</p>
+ */
+export const NOT_ON_THE_NETWORK = Symbol('a unix socket or named pipe — no browser can speak it');
+
+/** Which listener a request arrived on, since only one of them has a port to name. */
+export type DoorFacing = Loopback | typeof NOT_ON_THE_NETWORK;
+
 export interface DoorRefusal {
   readonly message: string;
 }
@@ -103,8 +154,13 @@ const REFUSED =
  * <p>Applied in `handle` before every route, including the ones that authenticate nothing, and for
  * both listeners, since they share one handler.</p>
  */
-export function admitsRequest(headers: IncomingHttpHeaders, at: Loopback): DoorRefusal | undefined {
-  return browserMarked(headers) || !loopbackHost(headers.host, at) ? { message: REFUSED } : undefined;
+export function admitsRequest(headers: IncomingHttpHeaders, at: DoorFacing): DoorRefusal | undefined {
+  return browserMarked(headers) || !addressedToUs(headers.host, at) ? { message: REFUSED } : undefined;
+}
+
+/** A socket has no address a `Host` could get wrong; a port has exactly one. */
+function addressedToUs(host: string | undefined, at: DoorFacing): boolean {
+  return at === NOT_ON_THE_NETWORK || loopbackHost(host, at);
 }
 
 /**

--- a/src_vs_code/src/brokerOrigin.ts
+++ b/src_vs_code/src/brokerOrigin.ts
@@ -36,8 +36,12 @@ import { errorBody, statusForErrorCode } from './brokerProtocol';
  * <p>Two of them are built, by `doorsFor` below: the port's door checks `Host`, the socket's cannot
  * (see {@link NOT_ON_THE_NETWORK}). They share one `note`, so a person is told once per window and
  * not once per listener.</p>
+ *
+ * <p>NOT exported, deliberately — a reviewer pointed out that a third listener added later would
+ * reach for this and get its own `said` flag, turning "once per window" back into once per
+ * listener. `doorsFor` is the only way to obtain a door, so that invariant is structural.</p>
  */
-export function behindTheDoor(
+function behindTheDoor(
   handle: (req: IncomingMessage, res: ServerResponse) => void,
   at: () => DoorFacing,
   respond: (res: ServerResponse, status: number, body: unknown) => void,
@@ -101,7 +105,7 @@ const REFUSAL_NOTE =
  * <p>`Connection: close` because the body was never read, and a keep-alive socket holding an unread
  * body is a socket doing nothing for anybody.</p>
  */
-export function turnAwayAtTheDoor(
+function turnAwayAtTheDoor(
   headers: IncomingHttpHeaders,
   at: DoorFacing,
   respond: (status: number, body: unknown) => void,

--- a/src_vs_code/src/credsAgentServer.ts
+++ b/src_vs_code/src/credsAgentServer.ts
@@ -14,7 +14,7 @@ import {
   parseUseRoute,
   statusForErrorCode,
 } from './brokerProtocol';
-import { behindTheDoor } from './brokerOrigin';
+import { doorsFor } from './brokerOrigin';
 import { ReadRouteSources, readRouteBody } from './brokerReadRoutes';
 import { describeError } from './describeError';
 import { BrokerDoor, McpCreateHooks, mcpDoor } from './brokerMcpDoor';
@@ -250,7 +250,7 @@ export class CredsAgentServer implements vscode.Disposable {
       const { server, port } = await startLoopbackServer();
       this.server = server;
       this.port = port;
-      server.on('request', this.served);
+      server.on('request', this.doors.onThePort);
       await this.openExtraListener();
       this.announce();
     });
@@ -440,7 +440,7 @@ export class CredsAgentServer implements vscode.Disposable {
     }
     try {
       this.extra = await startExtraListener(
-        this.served,
+        this.doors.onTheSocket,
         address,
         process.platform,
       );
@@ -592,10 +592,10 @@ export class CredsAgentServer implements vscode.Disposable {
     );
   }
 
-  /** The router, behind the door — see `behindTheDoor` for why it is a wrapper and not a branch. */
-  private readonly served = behindTheDoor(
+  /** The router, behind one door per listener — see `brokerOrigin.ts` for why, and why two. */
+  private readonly doors = doorsFor(
     (req, res) => void this.handle(req, res),
-    () => ({ port: this.port }),
+    () => this.port,
     (res, status, body) => this.respond(res, status, body),
     (message) => this.note(message),
   );

--- a/src_vs_code/src/test/brokerOrigin.test.ts
+++ b/src_vs_code/src/test/brokerOrigin.test.ts
@@ -1,6 +1,6 @@
 import * as assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { admitsRequest } from '../brokerOrigin';
+import { NOT_ON_THE_NETWORK, admitsRequest } from '../brokerOrigin';
 
 /**
  * The broker's door, decided on headers alone.
@@ -84,4 +84,41 @@ test('the refusal says what this is, so a person reading a log knows why', () =>
   const message = admitsRequest({ host: 'evil.example' } as never, AT)?.message ?? '';
   assert.match(message, /not a web service/);
   assert.match(message, /command-line tools/);
+});
+
+/**
+ * The second listener — a Unix socket on POSIX, a named pipe on Windows.
+ *
+ * <p>It shares the handler with the loopback port, so it inherited the `Host` check, and there is
+ * no `Host` it can pass: a caller reaching the broker this way was never told a port, so the URL it
+ * composes cannot name the one we are listening on. That broke the WSL bridge's whole reason for
+ * existing — a Linux `creds` naming an entry by alias, with no endpoint file and no port — and it
+ * broke it on main rather than in review, because the case is POSIX-only and lives in the CLI
+ * integration suite.</p>
+ *
+ * <p>Dropping the check here is not a hole. `Host` exists to stop DNS rebinding, which is a browser
+ * attack, and no browser can open a Unix socket or a named pipe from a page. What guards this
+ * transport is the file mode (0600 on POSIX) and the grant token, exactly as before.</p>
+ */
+
+const overSocket = (headers: Record<string, unknown>): boolean =>
+  admitsRequest(headers as never, NOT_ON_THE_NETWORK) === undefined;
+
+test('over a socket there is no port to name, and a client is still admitted', () => {
+  assert.ok(overSocket({ host: '127.0.0.1:1' }), 'the port a socket client invents means nothing');
+  assert.ok(overSocket({ host: 'localhost' }), 'nor does its absence');
+  assert.ok(overSocket({}), 'nor does having no Host at all');
+});
+
+test('a socket is not a free pass: the browser headers still refuse', () => {
+  // Belt and braces rather than a threat model — nothing that can reach a pipe sends these — but
+  // the cost is nothing, and "the socket skips the door" is the wrong sentence to leave behind.
+  assert.ok(!overSocket({ host: '127.0.0.1:4123', origin: 'https://evil.example' }));
+  assert.ok(!overSocket({ host: '127.0.0.1:4123', 'sec-fetch-site': 'cross-site' }));
+});
+
+test('the PORT listener is unchanged by any of this', () => {
+  assert.ok(!admitted({ host: 'localhost' }), 'no port still means port 80, and we are not there');
+  assert.ok(!admitted({ host: '127.0.0.1:9999' }));
+  assert.ok(admitted({ host: '127.0.0.1:4123' }));
 });

--- a/src_vs_code/src/test/brokerOriginDoor.test.ts
+++ b/src_vs_code/src/test/brokerOriginDoor.test.ts
@@ -1,6 +1,10 @@
 import * as assert from 'node:assert/strict';
 import { test } from 'node:test';
+import * as fs from 'node:fs';
 import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { socketPathFor } from '../brokerListeners';
 import { call, code, share, world } from './brokerWorld';
 
 /**
@@ -98,5 +102,137 @@ test('the refusal says what this is', async () => {
     assert.match(String((answer.body as { error?: { message?: string } }).error?.message), /not a web service/);
   } finally {
     w.server.dispose();
+  }
+});
+
+/**
+ * The OTHER listener — and the reason this test exists at all.
+ *
+ * <p>Both listeners share one router, so the socket inherited the `Host` check, and there is no
+ * `Host` a socket client can pass: it was never told a port. The alias call over the socket — the
+ * WSL bridge's whole reason for existing — started answering 403, and it reached main, because the
+ * only thing exercising that path was a POSIX-only case in the CLI integration suite.</p>
+ *
+ * <p>This drives the real second listener through the real door on BOTH platforms: a unix socket on
+ * POSIX, a named pipe on Windows. Nothing else in the unit suite had ever opened it.</p>
+ */
+
+/**
+ * A request down the socket or pipe — there is no port here, which is the whole point.
+ *
+ * <p>The status can come back as `'closed'` rather than as a number: the door answers and then
+ * closes (`Connection: close`, because the body was never read), and over a pipe that close can
+ * beat the client's own write, which then sees EPIPE. So the CLIENT's view cannot decide whether a
+ * refusal happened — a crash looks the same from here, which the review gate pointed out is a test
+ * that passes for a door that stopped working. What decides is the note the door says, which is
+ * server-side and deterministic: see `refusedAtTheDoor`.</p>
+ */
+function overSocket(socketPath: string, route: string, headers: Record<string, string>): Promise<number | 'closed'> {
+  return new Promise((resolve, reject) => {
+    const request = http.request({ socketPath, path: route, method: 'GET', headers }, (response) => {
+      response.resume();
+      response.on('end', () => resolve(response.statusCode ?? 0));
+    });
+    request.on('error', (error: NodeJS.ErrnoException) => {
+      const hungUp = error.code === 'EPIPE' || error.code === 'ECONNRESET';
+      return hungUp ? resolve('closed') : reject(error);
+    });
+    request.end();
+  });
+}
+
+/** The door's own record that it turned something away — said once per window, into the journal. */
+const saidSo = (w: { audit: string[] }): boolean =>
+  w.audit.some((line) => line.includes('browser-shaped request'));
+
+/**
+ * Wait for that record, briefly.
+ *
+ * <p>Over a pipe the client can see its own write fail before the server has finished answering,
+ * so "the client is back" is not "the server is done". Polling rather than sleeping: it returns as
+ * soon as the note is there, and gives up in a tenth of a second so a real regression fails fast.</p>
+ */
+async function refusedAtTheDoor(w: { audit: string[] }): Promise<boolean> {
+  for (let waited = 0; waited < 100 && !saidSo(w); waited += 5) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  return saidSo(w);
+}
+
+/** A window with its SECOND listener open, and the address a bridge would forward. */
+function withSocket(): { w: ReturnType<typeof world>; address: string; dir: string } {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'creds-door-'));
+  const w = world({ storageDir: dir });
+  const address = socketPathFor(dir, process.pid, process.platform);
+  assert.notEqual(address, undefined, 'the harness knows where the second listener would be');
+  return { w, address: address as string, dir };
+}
+
+/** A POST down the socket, since the token door is a POST route. */
+function post(
+  socketPath: string,
+  route: string,
+  headers: Record<string, string>,
+  body: unknown,
+): Promise<{ status: number; body: string }> {
+  const payload = JSON.stringify(body);
+  return new Promise((resolve, reject) => {
+    const request = http.request(
+      { socketPath, path: route, method: 'POST', headers: { 'Content-Type': 'application/json', ...headers } },
+      (response) => {
+        let text = '';
+        response.on('data', (chunk) => {
+          text += String(chunk);
+        });
+        response.on('end', () => resolve({ status: response.statusCode ?? 0, body: text }));
+      },
+    );
+    request.on('error', reject);
+    request.end(payload);
+  });
+}
+
+/**
+ * ONE window, three questions — because the pipe name carries the pid, so two windows in one test
+ * process would fight over the same address. That is not a harness quirk: `socketPathFor` is per
+ * pid precisely because one VS Code window is one process, and a second world here is a situation
+ * the product does not have. Sequential subtests share the window, in the order the door sees them.
+ */
+test('the socket listener, through the real door', async (t) => {
+  const { w, address, dir } = withSocket();
+  try {
+    await share(w);
+
+    await t.test('admits a client that cannot name a port', async () => {
+      // What the bridge sends: a URL it invented, because nobody told it a port.
+      assert.equal(await overSocket(address, '/v1/health', { Host: '127.0.0.1:1' }), 200);
+      assert.equal(await overSocket(address, '/v1/health', {}), 200, 'nor does having no Host at all');
+      assert.equal(saidSo(w), false, 'and the door turned nothing away');
+    });
+
+    await t.test('still refuses the browser headers, which cost nothing to keep', async () => {
+      const refused = await overSocket(address, '/v1/health', { Origin: 'https://evil.example' });
+
+      // The client's view first — it must never be served — and then the door's own record, which
+      // is what tells a REFUSAL from a crash. "Not 200" alone would pass for a listener that died.
+      assert.notEqual(refused, 200, `a browser header must not be served, got ${String(refused)}`);
+      assert.ok(await refusedAtTheDoor(w), 'the door has to say it turned this away');
+    });
+
+    await t.test('is not an authentication bypass: a call with no token is still refused', async () => {
+      // The invariant the Host exemption rests on, asserted rather than assumed. The socket's own
+      // guard is its file mode and the grant token; if this change had let the router run without
+      // one, both subtests above would still pass. (A reviewer asked for exactly this.)
+      const noToken = await post(address, '/v1/use/exec', {}, { command: 'id' });
+      const wrongToken = await post(address, '/v1/use/exec', { Authorization: 'Bearer nope' }, { command: 'id' });
+
+      assert.equal(noToken.status, 401, noToken.body);
+      assert.equal(wrongToken.status, 401, wrongToken.body);
+      assert.deepEqual(w.ran, [], 'and nothing ran');
+      assert.deepEqual(w.dialogs, [], 'and nobody was asked');
+    });
+  } finally {
+    w.server.dispose();
+    fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/src_vs_code/src/test/brokerOriginDoor.test.ts
+++ b/src_vs_code/src/test/brokerOriginDoor.test.ts
@@ -137,6 +137,7 @@ function overSocket(socketPath: string, route: string, headers: Record<string, s
       const hungUp = error.code === 'EPIPE' || error.code === 'ECONNRESET';
       return hungUp ? resolve('closed') : reject(error);
     });
+    onlyForSoLong(request, reject);
     request.end();
   });
 }
@@ -146,17 +147,39 @@ const saidSo = (w: { audit: string[] }): boolean =>
   w.audit.some((line) => line.includes('browser-shaped request'));
 
 /**
- * Wait for that record, briefly.
+ * Wait for that record.
  *
  * <p>Over a pipe the client can see its own write fail before the server has finished answering,
- * so "the client is back" is not "the server is done". Polling rather than sleeping: it returns as
- * soon as the note is there, and gives up in a tenth of a second so a real regression fails fast.</p>
+ * so "the client is back" is not "the server is done". Polling rather than sleeping: it returns the
+ * moment the note is there, so the green case costs a few milliseconds. The budget is generous
+ * because a tight one is a flaky test on a loaded runner and buys nothing — a real regression never
+ * produces the note at all, and then this is two seconds, once.</p>
  */
 async function refusedAtTheDoor(w: { audit: string[] }): Promise<boolean> {
-  for (let waited = 0; waited < 100 && !saidSo(w); waited += 5) {
+  for (let waited = 0; waited < WAIT_FOR_THE_NOTE_MS && !saidSo(w); waited += 5) {
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   return saidSo(w);
+}
+
+const WAIT_FOR_THE_NOTE_MS = 2_000;
+
+/**
+ * How long a socket request may take before the test gives up.
+ *
+ * <p>Without one, a listener that accepts a connection and then stalls hangs the runner for ever:
+ * `http.request` has no deadline of its own, and node:test never reaches the cleanup. A regression
+ * should fail, not wedge CI.</p>
+ */
+const SOCKET_DEADLINE_MS = 5_000;
+
+/** Destroy a request that is going nowhere, so the promise settles either way. */
+function onlyForSoLong(request: http.ClientRequest, reject: (why: Error) => void): void {
+  request.setTimeout(SOCKET_DEADLINE_MS, () => {
+    const why = new Error(`no answer over the socket within ${SOCKET_DEADLINE_MS}ms`);
+    request.destroy(why);
+    reject(why);
+  });
 }
 
 /** A window with its SECOND listener open, and the address a bridge would forward. */
@@ -188,6 +211,7 @@ function post(
       },
     );
     request.on('error', reject);
+    onlyForSoLong(request, reject);
     request.end(payload);
   });
 }

--- a/src_vs_code/src/test/brokerWorld.ts
+++ b/src_vs_code/src/test/brokerWorld.ts
@@ -80,6 +80,15 @@ function world(options: {
   mcpEntries?: Record<string, unknown>[];
   /** How an entry id resolves for an MCP use call. Absent means this window serves none. */
   mcpUse?: 'usable' | 'closed';
+  /**
+   * Where the window stores things — and, because it is what `socketPathFor` needs, the switch
+   * that makes the server open its SECOND listener (a unix socket, or a named pipe on Windows).
+   *
+   * <p>Absent for almost every test: a port is all they need, and a real window whose storage path
+   * is too long for the OS limit runs on the port alone. Pass it when the transport under test is
+   * the socket one — the door refused every alias call over it, and nothing here could see that.</p>
+   */
+  storageDir?: string;
   /** Whether this window can move entries to the Trash. Absent means it cannot. */
   trash?: boolean;
   /** How a create request is answered: accepted into a folder, refused, or not served at all. */
@@ -144,7 +153,7 @@ function world(options: {
     () => {
       w.presence += 1;
     },
-    undefined,
+    options.storageDir,
     maskerFor(w, options),
     burnerFor(w, options.burns),
     aliasResolverFor(options.alias),


### PR DESCRIPTION
`main` is red. `creds-cli-itest.cjs` has been saying so since the browser guard landed:

```
FAIL  a call by NAME works over the socket too, without any endpoint file  (code 93)
```

## What broke

The broker has **two listeners sharing one router**: a loopback TCP port, and a unix socket — a named pipe on Windows — opened by `openExtraListener`. The second one exists because Remote-SSH forwards a socket and the WSL bridge relays into one: a Linux `creds` cannot reach a Windows loopback port.

The door was wrapped around the shared router, so the socket inherited the `Host` check, which requires `Host` to name a loopback hostname **and this window's exact TCP port**. A caller over the socket was never told a port — that is the whole reason it is on a socket — so the one it invents cannot match.

A token carries `<port>.<secret>`, so the token path over the socket kept working by accident. The **alias** path, which has no endpoint file and no port, did not. That is the bridge's main use.

## The fix

A door per listener rather than a door per router. `doorsFor` builds both and shares the once-per-window flag between them, so a person is still told once per window and not once per listener.

`NOT_ON_THE_NETWORK` is the socket's facing: the `Host` check is skipped there, the browser-header checks (`Origin`, `Sec-Fetch-Site`) are not, and the port listener is unchanged.

## Why that is not a hole

`Host` does exactly one job in this design, and the guard's own record says so: `Origin` closes the cross-origin POST; **`Host` closes DNS rebinding**. Rebinding is a browser attack, and no page can open a unix socket or a Windows named pipe — there is no web API for either. On that transport the check protects against nothing and refuses everything.

What guards the socket is what guarded it before the door existed: mode `0600` on POSIX, and the grant token — which a new subtest now asserts, because the exemption rests on it.

## Why it reached main

The only thing exercising the path is one case in `creds-cli-itest.cjs` guarded by `process.platform !== 'win32'`, and the change was written on Windows.

There are unit tests now. `brokerOriginDoor.test.ts` drives the **real second listener** on both platforms — the first unit test that has ever opened it — and they share one window, because `socketPathFor` keys the pipe name by pid.

## Test plan

- [x] Teeth: with the socket facing rewired to the port's, the end-to-end test fails with *"a socket has no address a Host could get wrong"*
- [x] `npm run lint`, `npm run typecheck`
- [x] Full unit suite: 3838 pass, 0 fail
- [x] `creds-cli-itest.cjs` — all checks passed
- [x] `agent-broker-itest.cjs` — all checks passed
- [x] `plan-lifecycle.mjs` — clean
- [ ] Linux CI, which is the one that could see this in the first place

## The gate

`proceed`. Four findings taken: the refusal assertion waits for the door's own journal note instead of accepting any non-200 (a crashed listener would have passed the first version); a negative-authorization subtest — no token and a wrong token over the socket are both 401; deadlines on both socket helpers so a stalled listener fails instead of wedging CI; and `behindTheDoor` is no longer exported, so a future listener cannot get its own `said` flag.

Fourteen rejected with reasons, five of which were one misreading repeated across reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Исправления**
  * Исправлена работа вызовов `creds` через Unix-сокет или именованный канал.
  * Проверка `Host` сохраняется для сетевого порта, а для локального сокета не применяется.
  * Защита браузерными заголовками и токеном доступа продолжает работать на обоих способах подключения.

* **Тесты**
  * Добавлены модульные и интеграционные проверки для POSIX и Windows, включая отказ подозрительных браузерных запросов.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->