### PR TITLE
chore(release): extension 1.6.0

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] — the audit's nine findings closed, and a second code where enrolment asks for two
+
 ### Added
 
 - **The next one-time code, beside the current one, where you ask for it.** Binding a virtual MFA

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Your coding agent can run the migration — and can never be handed the password. SSH hosts, keys, databases, VPNs, secrets and config files in VS Code, with optional end-to-end encrypted team sync.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
Cuts **CredsForDevs 1.6.0** from the twelve entries waiting in `[Unreleased]`: nine security fixes, two bugs and one feature.

The security half is the 2026-09-09 audit landing one finding at a time. The feature is the one-time-code **pair** — binding a virtual MFA device asks for two consecutive codes and the viewer computed one (#75).

Two files, as every release commit here touches: `package.json` 1.5.0 → 1.6.0, and the `[Unreleased]` heading becomes `[1.6.0]`.

**Verified, not intended**
- `npm test` over a deleted `out/`: 3901 tests, 3897 pass, 0 fail, 4 pre-existing skips; `npm run typecheck` clean.
- The **artefact** was checked rather than the source: `vsce package` builds, and the version inside the .vsix reads 1.6.0 in both `extension/package.json` and the vsixmanifest `Identity`.

Merging this publishes nothing. The release is the tag `extension-v1.6.0`, pushed after this lands.

**Noted, not changed:** `src_vs_code/package-lock.json` still says 0.98.0 — out of step for many releases, and no release commit here has ever touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)