### PR TITLE
chore(release): extension 1.7.0

### DIFF
--- a/src_vs_code/CHANGELOG.md
+++ b/src_vs_code/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **CredsForDevs** are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.0] — the forms say what they are doing, the tree says what the server is, and the dialog says who is asking
 
 ### Fixed
 

--- a/src_vs_code/package.json
+++ b/src_vs_code/package.json
@@ -2,7 +2,7 @@
   "name": "creds-for-devs",
   "displayName": "CredsForDevs",
   "description": "Your coding agent can run the migration — and can never be handed the password. SSH hosts, keys, databases, VPNs, secrets and config files in VS Code, with optional end-to-end encrypted team sync.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "publisher": "remsoftdev",
   "license": "MIT",
   "icon": "media/icon.png",


### PR DESCRIPTION
Two files, as every release commit here touches: the manifest version and the CHANGELOG heading. The release workflow refuses to publish when the tag and the manifest disagree, and it cuts the release notes from the section named for the tagged version.

Sixteen entries ship: nine fixes, three additions and four changes, from seven issues — #2, #48, #51, #53, #54, #55, #56, #57 and #61.

The sharpest is not in any issue. The bank form's weaving controls lived inside the Card fieldset, which is hidden whenever the form is not a card, so ticking *Store the IBAN woven with a decoy* showed no picker, no warning and no picture — and the save wove the IBAN anyway, under a method the person never saw. That method is stored nowhere by design, so the value was unreadable from the moment it was written. Found while verifying #51.

After this merges, four tags: `extension-v1.7.0`, `server-v0.7.0`, `mcp-v0.6.0`, `cli-v0.1.6`. The last two fill the caller record the consent modal now shows; the server opens its metrics document to administrators and reports the backup destinations that are configured rather than only the ones the last run wrote to.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm test` — 4096 tests, 4092 pass, 4 skipped, 0 fail
- [x] Vault server 769, CLI 78, MCP 40, broker client 81 — all pass
- [x] `plan-lifecycle` clean
- [x] The manifest version and the tag to be pushed agree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
