### PR TITLE
fix(relay): a socket path longer than the platform allows is answered, not thrown at

### DIFF
--- a/.github/workflows/ci-clients.yml
+++ b/.github/workflows/ci-clients.yml
@@ -4,6 +4,24 @@ name: ci · clients
 # of the three ran in CI — the server workflow builds the whole solution but runs only its own tests.
 # This job runs the other three. No path filter: a required check that a pull request can skip is a
 # check that protects nothing.
+#
+# **On macOS as well as Linux, since 2026-09-12, and only for these three.** The clients are the
+# components that touch the local operating system — unix sockets, the WSL bridge, announcement
+# files — and macOS was exercised NOWHERE except the release workflow, which runs after a tag. So a
+# macOS defect could not be found by a pull request, structurally rather than by bad luck. It cost
+# exactly that: `creds` 0.1.6 failed both macOS legs of the 1.7.0 release on a unix socket path one
+# character over that platform's 104-byte `sun_path`, and the release had already shipped the other
+# three products by then.
+#
+# The server, the vault and anything with a database stay on Linux alone — they are deployed to
+# Linux containers and a macOS run would assert nothing anybody ships.
+#
+# UNCONDITIONAL rather than path-filtered, deliberately, and the reasoning is specific to this
+# repository. The runners are free here (a public repository), the whole job is under a minute, and
+# a filter would be a second thing to keep true: the directories are `src_cli`, `src_mcp` and
+# `src_broker_client`, so a filter written as `src/cli/**` matches nothing and the leg silently
+# never runs — the same shape of failure as the one above, and harder to notice because a skipped
+# job looks like a passing one.
 on:
   push:
     branches: [main]
@@ -20,8 +38,12 @@ permissions:
 
 jobs:
   build-test:
-    name: clients · build · test
-    runs-on: ubuntu-latest
+    name: clients · build · test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       # This job builds and RUNS code from a pull request, so the checkout must not leave the
       # token behind in the local git config where that code could reach it. `contents: read` bounds

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -146,7 +146,7 @@ internal static class AgentRelay
         // socket that cannot exist there.
         if (OperatingSystem.IsWindows())
         {
-            Console.Error.WriteLine(
+            await Console.Error.WriteLineAsync(
                 "[creds-for-devs] `creds relay` runs INSIDE WSL, where ssh cannot reach the "
                     + "agent's named pipe. On Windows the agent is already reachable.");
             return contract.Exit("usage");
@@ -159,7 +159,7 @@ internal static class AgentRelay
         // line for `eval` is the least useful failure it could have.
         if (TooLongForSocket(path))
         {
-            Console.Error.WriteLine(TooLongMessage(path));
+            await Console.Error.WriteLineAsync(TooLongMessage(path));
             return contract.Exit("usage");
         }
 
@@ -187,7 +187,7 @@ internal static class AgentRelay
         catch (Exception e)
             when (e is SocketException or IOException or UnauthorizedAccessException or ArgumentException)
         {
-            Console.Error.WriteLine($"[creds-for-devs] could not listen on {path}: {e.Message}");
+            await Console.Error.WriteLineAsync($"[creds-for-devs] could not listen on {path}: {e.Message}");
             return contract.Exit("brokerFailure");
         }
 
@@ -199,9 +199,9 @@ internal static class AgentRelay
         };
         AppDomain.CurrentDomain.ProcessExit += (_, _) => Remove(path);
 
-        Console.Error.WriteLine($"[creds-for-devs] relay listening on {path}");
+        await Console.Error.WriteLineAsync($"[creds-for-devs] relay listening on {path}");
         // On stdout so `eval "$(creds relay &)"` is not needed and a person can simply read it.
-        Console.Out.WriteLine($"export SSH_AUTH_SOCK={path}");
+        await Console.Out.WriteLineAsync($"export SSH_AUTH_SOCK={path}");
         await AcceptLoopAsync(listener, stopping.Token).ConfigureAwait(false);
         Remove(path);
         return 0;
@@ -276,3 +276,4 @@ internal static class AgentRelay
         }
     }
 }
+

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -74,6 +74,21 @@ internal static class AgentRelay
             ? $"/tmp/creds-agent-{SafeUser(user)}.sock"
             : Path.Combine(runtimeDir, "creds-agent.sock");
 
+    /// <summary>
+    /// How long a unix socket path may be: 104 characters on macOS, 108 elsewhere.
+    /// </summary>
+    /// <remarks>
+    /// The kernel's <c>sun_path</c>, and .NET enforces it in <see cref="UnixDomainSocketEndPoint"/>'s
+    /// constructor with an <see cref="ArgumentOutOfRangeException"/> — which is neither a
+    /// <c>SocketException</c> nor an <c>IOException</c>, so it escaped both of this file's guards
+    /// and took the process with it. It is not a theoretical limit on macOS: the temporary
+    /// directory alone is about fifty characters there, which is how the 1.7.0 release found it.
+    /// </remarks>
+    internal static int MaxSocketPathLength => OperatingSystem.IsMacOS() ? 104 : 108;
+
+    /// <summary>Whether this path is longer than a domain socket may be on this platform.</summary>
+    internal static bool TooLongForSocket(string path) => path.Length > MaxSocketPathLength;
+
     internal static string SocketPathHere() =>
         Environment.GetEnvironmentVariable(SocketOverrideVariable) is { Length: > 0 } custom
             ? custom
@@ -91,7 +106,10 @@ internal static class AgentRelay
     /// </remarks>
     internal static async Task<bool> IsStaleAsync(string path)
     {
-        if (!File.Exists(path))
+        // A path nothing could ever have bound is not a corpse to remove. This method's caller
+        // DELETES what it is told about, so answering "stale" here would unlink an arbitrary file
+        // for the crime of living somewhere with a long name.
+        if (!File.Exists(path) || TooLongForSocket(path))
         {
             return false;
         }
@@ -121,6 +139,19 @@ internal static class AgentRelay
         }
 
         var path = SocketPathHere();
+        // Refused here, with the number, rather than thrown at from inside the endpoint's
+        // constructor. `CREDS_RELAY_SOCKET` and `XDG_RUNTIME_DIR` are both somebody else's strings,
+        // and an unhandled ArgumentOutOfRangeException from a binary whose whole job is to print a
+        // line for `eval` is the least useful failure it could have.
+        if (TooLongForSocket(path))
+        {
+            Console.Error.WriteLine(
+                $"[creds-for-devs] {path} is {path.Length} characters; a unix socket path may be at "
+                    + $"most {MaxSocketPathLength} on this platform. Set {SocketOverrideVariable} to "
+                    + "something shorter.");
+            return contract.Exit("usage");
+        }
+
         var claimed = await ClaimAsync(path, contract).ConfigureAwait(false);
         if (claimed != 0)
         {
@@ -138,7 +169,12 @@ internal static class AgentRelay
             // with it would mean the mask did not take.
             File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
         }
-        catch (Exception e) when (e is SocketException or IOException or UnauthorizedAccessException)
+        // ArgumentException as well as the three: the endpoint's constructor is the one call here
+        // that refuses a VALUE rather than failing an operation, and its refusal was escaping into
+        // an unhandled crash. The guard above catches the known case by name; this catches the next
+        // one somebody finds, with the same sentence rather than a stack trace.
+        catch (Exception e)
+            when (e is SocketException or IOException or UnauthorizedAccessException or ArgumentException)
         {
             Console.Error.WriteLine($"[creds-for-devs] could not listen on {path}: {e.Message}");
             return contract.Exit("brokerFailure");

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -153,14 +153,10 @@ internal static class AgentRelay
         }
 
         var path = SocketPathHere();
-        // Refused here, with the number, rather than thrown at from inside the endpoint's
-        // constructor. `CREDS_RELAY_SOCKET` and `XDG_RUNTIME_DIR` are both somebody else's strings,
-        // and an unhandled ArgumentOutOfRangeException from a binary whose whole job is to print a
-        // line for `eval` is the least useful failure it could have.
-        if (TooLongForSocket(path))
+        var tooLong = await RefuseIfTooLongAsync(path, contract).ConfigureAwait(false);
+        if (tooLong is { } refusal)
         {
-            await Console.Error.WriteLineAsync(TooLongMessage(path));
-            return contract.Exit("usage");
+            return refusal;
         }
 
         var claimed = await ClaimAsync(path, contract).ConfigureAwait(false);
@@ -205,6 +201,28 @@ internal static class AgentRelay
         await AcceptLoopAsync(listener, stopping.Token).ConfigureAwait(false);
         Remove(path);
         return 0;
+    }
+
+    /// <summary>
+    /// The exit code when this path cannot be a socket at all, or null when it can.
+    /// </summary>
+    /// <remarks>
+    /// <para>Its own function so the decision is a TEST rather than three lines inside a method
+    /// that binds a socket and then serves it — nothing can run that in a unit test, which is how
+    /// the refusal it replaces went out uncovered.</para>
+    /// <para>Refused here rather than thrown at from inside the endpoint's constructor.
+    /// <c>CREDS_RELAY_SOCKET</c> and <c>XDG_RUNTIME_DIR</c> are both somebody else's strings, and an
+    /// unhandled <c>ArgumentOutOfRangeException</c> from a binary whose whole job is to print one
+    /// line for <c>eval</c> is the least useful failure it could have.</para>
+    /// </remarks>
+    internal static async Task<int?> RefuseIfTooLongAsync(string path, BrokerContract contract)
+    {
+        if (!TooLongForSocket(path))
+        {
+            return null;
+        }
+        await Console.Error.WriteLineAsync(TooLongMessage(path)).ConfigureAwait(false);
+        return contract.Exit("usage");
     }
 
     /// <summary>Take the path, or refuse it to whoever is already serving it.</summary>

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -1,5 +1,6 @@
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using CredsBroker;
 
@@ -75,19 +76,28 @@ internal static class AgentRelay
             : Path.Combine(runtimeDir, "creds-agent.sock");
 
     /// <summary>
-    /// How long a unix socket path may be: 104 characters on macOS, 108 elsewhere.
+    /// How many BYTES a unix socket path may be: 103 on macOS, 107 elsewhere.
     /// </summary>
     /// <remarks>
-    /// The kernel's <c>sun_path</c>, and .NET enforces it in <see cref="UnixDomainSocketEndPoint"/>'s
-    /// constructor with an <see cref="ArgumentOutOfRangeException"/> — which is neither a
-    /// <c>SocketException</c> nor an <c>IOException</c>, so it escaped both of this file's guards
-    /// and took the process with it. It is not a theoretical limit on macOS: the temporary
-    /// directory alone is about fifty characters there, which is how the 1.7.0 release found it.
+    /// <para>The kernel's <c>sun_path</c>, and .NET enforces it in
+    /// <see cref="UnixDomainSocketEndPoint"/>'s constructor with an
+    /// <see cref="ArgumentOutOfRangeException"/> — which is neither a <c>SocketException</c> nor an
+    /// <c>IOException</c>, so it escaped both of this file's guards and took the process with it.
+    /// It is not a theoretical limit on macOS: the temporary directory alone is about fifty
+    /// characters there, which is how the 1.7.0 release found it.</para>
+    /// <para><b>Bytes, and one fewer than the exception says.</b> Both corrections came from review
+    /// and both were then MEASURED against the runtime rather than argued about. The path is encoded
+    /// as UTF-8 and a NUL is appended, so the exception's "must be between 1 and 108" describes the
+    /// buffer and the largest pathname actually accepted is 107. And because it is the encoded form
+    /// that is measured, a path of 107 CHARACTERS holding one two-byte character is 108 bytes and is
+    /// refused — so counting characters would let exactly the paths a non-ASCII home directory
+    /// produces through the guard and into the throw.</para>
     /// </remarks>
-    internal static int MaxSocketPathLength => OperatingSystem.IsMacOS() ? 104 : 108;
+    internal static int MaxSocketPathBytes => OperatingSystem.IsMacOS() ? 103 : 107;
 
     /// <summary>Whether this path is longer than a domain socket may be on this platform.</summary>
-    internal static bool TooLongForSocket(string path) => path.Length > MaxSocketPathLength;
+    internal static bool TooLongForSocket(string path) =>
+        Encoding.UTF8.GetByteCount(path) > MaxSocketPathBytes;
 
     /// <summary>
     /// What a person is told when the path cannot be a socket — a separate function so the SENTENCE
@@ -95,13 +105,16 @@ internal static class AgentRelay
     /// </summary>
     /// <remarks>
     /// It names four things, and each earns its place: the path, because it may have come from an
-    /// environment variable the person has forgotten setting; its length and the limit, because
-    /// "too long" without the numbers leaves them guessing how much to cut; and the variable to
-    /// set, because otherwise the only remedy they can see is to move their home directory.
+    /// environment variable the person has forgotten setting; its size and the limit, because "too
+    /// long" without the numbers leaves them guessing how much to cut; and the variable to set,
+    /// because otherwise the only remedy they can see is to move their home directory. In BYTES,
+    /// because that is what is measured — and a person whose path is short but non-ASCII would
+    /// otherwise read a number that looks like it fits.
     /// </remarks>
     internal static string TooLongMessage(string path) =>
-        $"[creds-for-devs] {path} is {path.Length} characters; a unix socket path may be at most "
-            + $"{MaxSocketPathLength} on this platform. Set {SocketOverrideVariable} to something shorter.";
+        $"[creds-for-devs] {path} is {Encoding.UTF8.GetByteCount(path)} bytes; a unix socket path "
+            + $"may be at most {MaxSocketPathBytes} on this platform. Set {SocketOverrideVariable} "
+            + "to something shorter.";
 
     internal static string SocketPathHere() =>
         Environment.GetEnvironmentVariable(SocketOverrideVariable) is { Length: > 0 } custom
@@ -133,8 +146,12 @@ internal static class AgentRelay
             await probe.ConnectAsync(new UnixDomainSocketEndPoint(path)).ConfigureAwait(false);
             return false;
         }
-        catch (SocketException)
+        catch (Exception e) when (e is SocketException or ArgumentException)
         {
+            // ArgumentException as well, and it is the belt to the guard's braces. The guard above
+            // exists to produce a SENTENCE; this exists so that being wrong about the exact limit by
+            // one byte can never again escape a method whose whole contract is to answer true or
+            // false. A path the endpoint refuses is a path nothing is serving.
             return true;
         }
     }

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -89,6 +89,20 @@ internal static class AgentRelay
     /// <summary>Whether this path is longer than a domain socket may be on this platform.</summary>
     internal static bool TooLongForSocket(string path) => path.Length > MaxSocketPathLength;
 
+    /// <summary>
+    /// What a person is told when the path cannot be a socket — a separate function so the SENTENCE
+    /// is a test rather than a thing somebody reads once in a log.
+    /// </summary>
+    /// <remarks>
+    /// It names four things, and each earns its place: the path, because it may have come from an
+    /// environment variable the person has forgotten setting; its length and the limit, because
+    /// "too long" without the numbers leaves them guessing how much to cut; and the variable to
+    /// set, because otherwise the only remedy they can see is to move their home directory.
+    /// </remarks>
+    internal static string TooLongMessage(string path) =>
+        $"[creds-for-devs] {path} is {path.Length} characters; a unix socket path may be at most "
+            + $"{MaxSocketPathLength} on this platform. Set {SocketOverrideVariable} to something shorter.";
+
     internal static string SocketPathHere() =>
         Environment.GetEnvironmentVariable(SocketOverrideVariable) is { Length: > 0 } custom
             ? custom
@@ -145,10 +159,7 @@ internal static class AgentRelay
         // line for `eval` is the least useful failure it could have.
         if (TooLongForSocket(path))
         {
-            Console.Error.WriteLine(
-                $"[creds-for-devs] {path} is {path.Length} characters; a unix socket path may be at "
-                    + $"most {MaxSocketPathLength} on this platform. Set {SocketOverrideVariable} to "
-                    + "something shorter.");
+            Console.Error.WriteLine(TooLongMessage(path));
             return contract.Exit("usage");
         }
 

--- a/src_cli/src/AgentRelay.cs
+++ b/src_cli/src/AgentRelay.cs
@@ -146,7 +146,7 @@ internal static class AgentRelay
         // socket that cannot exist there.
         if (OperatingSystem.IsWindows())
         {
-            await Console.Error.WriteLineAsync(
+            Console.Error.WriteLine(
                 "[creds-for-devs] `creds relay` runs INSIDE WSL, where ssh cannot reach the "
                     + "agent's named pipe. On Windows the agent is already reachable.");
             return contract.Exit("usage");
@@ -183,7 +183,7 @@ internal static class AgentRelay
         catch (Exception e)
             when (e is SocketException or IOException or UnauthorizedAccessException or ArgumentException)
         {
-            await Console.Error.WriteLineAsync($"[creds-for-devs] could not listen on {path}: {e.Message}");
+            Console.Error.WriteLine($"[creds-for-devs] could not listen on {path}: {e.Message}");
             return contract.Exit("brokerFailure");
         }
 
@@ -195,9 +195,9 @@ internal static class AgentRelay
         };
         AppDomain.CurrentDomain.ProcessExit += (_, _) => Remove(path);
 
-        await Console.Error.WriteLineAsync($"[creds-for-devs] relay listening on {path}");
+        Console.Error.WriteLine($"[creds-for-devs] relay listening on {path}");
         // On stdout so `eval "$(creds relay &)"` is not needed and a person can simply read it.
-        await Console.Out.WriteLineAsync($"export SSH_AUTH_SOCK={path}");
+        Console.Out.WriteLine($"export SSH_AUTH_SOCK={path}");
         await AcceptLoopAsync(listener, stopping.Token).ConfigureAwait(false);
         Remove(path);
         return 0;
@@ -294,4 +294,5 @@ internal static class AgentRelay
         }
     }
 }
+
 

--- a/src_cli/src/RelayPipe.cs
+++ b/src_cli/src/RelayPipe.cs
@@ -85,8 +85,13 @@ internal static class RelayPipe
                 ? await ConnectPipeAsync(name).ConfigureAwait(false)
                 : await ConnectUnixAsync(address).ConfigureAwait(false);
         }
+        // ArgumentException among them: the address is ANNOUNCED by another process, and a unix
+        // path longer than the platform's `sun_path` makes the endpoint's constructor refuse the
+        // value rather than the connection — an ArgumentOutOfRangeException, which is none of the
+        // others and would take the process down instead of meaning "could not connect". The same
+        // escape crashed `creds relay` on macOS; found by the 1.7.0 release.
         catch (Exception e) when (e is IOException or SocketException or TimeoutException
-            or UnauthorizedAccessException or PlatformNotSupportedException)
+            or UnauthorizedAccessException or PlatformNotSupportedException or ArgumentException)
         {
             return null;
         }

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -213,4 +213,36 @@ public class AgentRelayTests
 
         refusal.Should().Be(BrokerContract.Current.Exit("usage"));
     }
+
+    /// <summary>
+    /// The whole refusal, through the REAL entry point: a too-long override stops the relay before
+    /// it binds anything.
+    /// </summary>
+    /// <remarks>
+    /// Not Windows, where RunAsync returns at its own guard before reaching this one — the relay
+    /// runs inside WSL by design. This is the only path through RunAsync a unit test can take,
+    /// because every other one ends at a bound socket being served.
+    /// </remarks>
+    [Fact]
+    public async Task TheRelayRefusesAnOverrideItCouldNeverBind()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+        var before = Environment.GetEnvironmentVariable(AgentRelay.SocketOverrideVariable);
+        Environment.SetEnvironmentVariable(
+            AgentRelay.SocketOverrideVariable,
+            "/tmp/" + new string('x', AgentRelay.MaxSocketPathLength) + ".sock");
+        try
+        {
+            var code = await AgentRelay.RunAsync(BrokerContract.Current);
+
+            code.Should().Be(BrokerContract.Current.Exit("usage"));
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(AgentRelay.SocketOverrideVariable, before);
+        }
+    }
 }

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -109,7 +109,16 @@ public class AgentRelayTests
     {
         // The common case after a crash: the file outlives the process. Refusing it would mean a
         // manual cleanup every time, which is how a relay becomes something people stop using.
-        var path = Path.Combine(Path.GetTempPath(), $"creds-relay-corpse-{Guid.NewGuid():N}.sock");
+        //
+        // The name is SHORT and the length is asserted, because this test is about a corpse and not
+        // about the length limit — and it used to be about both by accident. A 32-character GUID
+        // under macOS's temporary directory came to 105 characters, one over that platform's cap,
+        // so the endpoint's constructor threw before the question was ever asked. It failed on both
+        // macOS legs of the 1.7.0 release and blocked the CLI from publishing.
+        var path = Path.Combine(Path.GetTempPath(), $"creds-corpse-{Environment.ProcessId}.sock");
+        path.Length.Should().BeLessThanOrEqualTo(
+            AgentRelay.MaxSocketPathLength,
+            "this test is about a corpse, not about the path limit — see APathTooLongForASocketIsNotStale");
         await File.WriteAllTextAsync(path, string.Empty, TestContext.Current.CancellationToken);
         try
         {
@@ -119,5 +128,47 @@ public class AgentRelayTests
         {
             File.Delete(path);
         }
+    }
+    
+    /// <summary>
+    /// A path too long to BE a domain socket is answered, not thrown at.
+    /// </summary>
+    /// <remarks>
+    /// <para>macOS caps a unix socket path at 104 characters and Linux at 108, and .NET enforces
+    /// that in <c>UnixDomainSocketEndPoint</c>'s constructor with an
+    /// <c>ArgumentOutOfRangeException</c> — which is neither a <c>SocketException</c> nor an
+    /// <c>IOException</c>, so it escaped both guards in this file. On macOS the temporary directory
+    /// alone is fifty characters, which is how the release found it.</para>
+    /// <para>It answers FALSE rather than true. "Stale" means "a corpse we may remove", and this
+    /// method's caller deletes what it is told about — so a path nothing could ever have bound must
+    /// not be reported as a socket to unlink. Nothing is serving there, and nothing is ours to
+    /// delete either.</para>
+    /// </remarks>
+    [Fact]
+    public async Task APathTooLongForASocketIsNotStale()
+    {
+        var directory = Directory.CreateTempSubdirectory("creds-relay-long");
+        var path = Path.Combine(directory.FullName, new string('n', 200) + ".sock");
+        await File.WriteAllTextAsync(path, string.Empty, TestContext.Current.CancellationToken);
+        try
+        {
+            path.Length.Should().BeGreaterThan(AgentRelay.MaxSocketPathLength);
+            (await AgentRelay.IsStaleAsync(path)).Should().BeFalse();
+        }
+        finally
+        {
+            Directory.Delete(directory.FullName, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TheLengthLimitIsThePlatformOwn()
+    {
+        // 104 on macOS, 108 elsewhere. Asserted so the constant cannot drift into "whatever number
+        // made the test pass on the machine it was written on".
+        AgentRelay.MaxSocketPathLength
+            .Should().Be(OperatingSystem.IsMacOS() ? 104 : 108);
+        AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength)).Should().BeFalse();
+        AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength + 1)).Should().BeTrue();
     }
 }

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Sockets;
+
 using CredsBroker;
 using CredsCli;
 using FluentAssertions;
@@ -117,7 +119,7 @@ public class AgentRelayTests
         // macOS legs of the 1.7.0 release and blocked the CLI from publishing.
         var path = Path.Combine(Path.GetTempPath(), $"creds-corpse-{Environment.ProcessId}.sock");
         path.Length.Should().BeLessThanOrEqualTo(
-            AgentRelay.MaxSocketPathLength,
+            AgentRelay.MaxSocketPathBytes,
             "this test is about a corpse, not about the path limit — see APathTooLongForASocketIsNotStale");
         await File.WriteAllTextAsync(path, string.Empty, TestContext.Current.CancellationToken);
         try
@@ -134,7 +136,7 @@ public class AgentRelayTests
     /// A path too long to BE a domain socket is answered, not thrown at.
     /// </summary>
     /// <remarks>
-    /// <para>macOS caps a unix socket path at 104 characters and Linux at 108, and .NET enforces
+    /// <para>macOS caps a unix socket pathname at 103 BYTES and Linux at 107, and .NET enforces
     /// that in <c>UnixDomainSocketEndPoint</c>'s constructor with an
     /// <c>ArgumentOutOfRangeException</c> — which is neither a <c>SocketException</c> nor an
     /// <c>IOException</c>, so it escaped both guards in this file. On macOS the temporary directory
@@ -152,7 +154,7 @@ public class AgentRelayTests
         await File.WriteAllTextAsync(path, string.Empty, TestContext.Current.CancellationToken);
         try
         {
-            path.Length.Should().BeGreaterThan(AgentRelay.MaxSocketPathLength);
+            path.Length.Should().BeGreaterThan(AgentRelay.MaxSocketPathBytes);
             (await AgentRelay.IsStaleAsync(path)).Should().BeFalse();
         }
         finally
@@ -164,12 +166,38 @@ public class AgentRelayTests
     [Fact]
     public void TheLengthLimitIsThePlatformOwn()
     {
-        // 104 on macOS, 108 elsewhere. Asserted so the constant cannot drift into "whatever number
-        // made the test pass on the machine it was written on".
-        AgentRelay.MaxSocketPathLength
-            .Should().Be(OperatingSystem.IsMacOS() ? 104 : 108);
-        AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength)).Should().BeFalse();
-        AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength + 1)).Should().BeTrue();
+        // 103 on macOS, 107 elsewhere — one BELOW the number the exception quotes, because the path
+        // is encoded and a NUL appended, so the buffer limit and the pathname limit are not the same
+        // number. Asserted against the runtime rather than against the constant, so neither can
+        // drift into "whatever made the test pass on the machine it was written on".
+        AgentRelay.MaxSocketPathBytes.Should().Be(OperatingSystem.IsMacOS() ? 103 : 107);
+
+        var fits = new string('x', AgentRelay.MaxSocketPathBytes);
+        var over = new string('x', AgentRelay.MaxSocketPathBytes + 1);
+        AgentRelay.TooLongForSocket(fits).Should().BeFalse();
+        AgentRelay.TooLongForSocket(over).Should().BeTrue();
+
+        // The endpoint itself agrees, on whatever platform this is running. Without this the two
+        // constants are a claim about the runtime that nothing checks.
+        var _ = new UnixDomainSocketEndPoint(fits);
+        var refused = () => new UnixDomainSocketEndPoint(over);
+        refused.Should().Throw<ArgumentException>("the runtime is where this limit actually lives");
+    }
+
+    [Fact]
+    public void TheLimitIsBYTES_SoANonAsciiPathIsNotMeasuredInCharacters()
+    {
+        // The correction that matters most, and it is the same mistake as counting a PIN in UTF-16
+        // code units: the path is encoded as UTF-8 before it is measured. A path one character under
+        // the limit holding a single two-byte character is one byte OVER it — and counting
+        // characters would wave through exactly the paths a non-ASCII home directory produces.
+        var accented = "é" + new string('x', AgentRelay.MaxSocketPathBytes - 1);
+
+        accented.Length.Should().Be(AgentRelay.MaxSocketPathBytes, "it fits, counted the wrong way");
+        AgentRelay.TooLongForSocket(accented).Should().BeTrue("but it is one byte too long");
+
+        var refused = () => new UnixDomainSocketEndPoint(accented);
+        refused.Should().Throw<ArgumentException>("which is what the runtime says too");
     }
 
     [Theory]
@@ -182,21 +210,21 @@ public class AgentRelayTests
         // Relying on that is how this defect reached a tag: the old test inherited its input from
         // the environment and so tested the corpse case on Linux and the length cap on macOS,
         // without saying either.
-        var path = new string('x', AgentRelay.MaxSocketPathLength + over);
+        var path = new string('x', AgentRelay.MaxSocketPathBytes + over);
 
         AgentRelay.TooLongForSocket(path).Should().Be(over > 0);
 
         // And the sentence, because a refusal nobody can act on is a crash with better manners.
         var message = AgentRelay.TooLongMessage(path);
         message.Should().Contain(path.Length.ToString(), "the length they have");
-        message.Should().Contain(AgentRelay.MaxSocketPathLength.ToString(), "the length they may have");
+        message.Should().Contain(AgentRelay.MaxSocketPathBytes.ToString(), "the length they may have");
         message.Should().Contain(AgentRelay.SocketOverrideVariable, "and what to set to fix it");
     }
 
     [Fact]
     public async Task APathThatFitsIsNotRefused()
     {
-        var fits = new string('x', AgentRelay.MaxSocketPathLength);
+        var fits = new string('x', AgentRelay.MaxSocketPathBytes);
 
         (await AgentRelay.RefuseIfTooLongAsync(fits, BrokerContract.Current)).Should().BeNull(
             "null means carry on — the relay has a path it can bind");
@@ -207,7 +235,7 @@ public class AgentRelayTests
     {
         // The exit code matters as much as the sentence: the relay is started from a shell profile,
         // and a wrong path is the person's mistake to correct rather than a broker that is down.
-        var tooLong = new string('x', AgentRelay.MaxSocketPathLength + 1);
+        var tooLong = new string('x', AgentRelay.MaxSocketPathBytes + 1);
 
         var refusal = await AgentRelay.RefuseIfTooLongAsync(tooLong, BrokerContract.Current);
 
@@ -233,7 +261,7 @@ public class AgentRelayTests
         var before = Environment.GetEnvironmentVariable(AgentRelay.SocketOverrideVariable);
         Environment.SetEnvironmentVariable(
             AgentRelay.SocketOverrideVariable,
-            "/tmp/" + new string('x', AgentRelay.MaxSocketPathLength) + ".sock");
+            "/tmp/" + new string('x', AgentRelay.MaxSocketPathBytes) + ".sock");
         try
         {
             var code = await AgentRelay.RunAsync(BrokerContract.Current);

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Sockets;
+using System.Text;
 
 using CredsBroker;
 using CredsCli;
@@ -205,19 +206,28 @@ public class AgentRelayTests
     [InlineData(1)]
     public void TheRefusalNamesThePathTheLengthTheLimitAndTheWayOut(int over)
     {
-        // The BOUNDARY and the overflow, parameterised — 104 and 105 on macOS, 108 and 109
+        // The BOUNDARY and the overflow, parameterised — 103 and 104 bytes on macOS, 107 and 108
         // elsewhere — rather than whatever length a runner's temporary directory happens to give.
         // Relying on that is how this defect reached a tag: the old test inherited its input from
         // the environment and so tested the corpse case on Linux and the length cap on macOS,
         // without saying either.
-        var path = new string('x', AgentRelay.MaxSocketPathBytes + over);
+        //
+        // NON-ASCII on purpose. With an all-ASCII fixture the byte count and the character count are
+        // the same number, so a regression back to `path.Length` would pass every assertion below —
+        // which is exactly the fixture blindness that let the original defect through. The accent is
+        // two bytes, so the string is one character shorter than its size.
+        var path = "é" + new string('x', AgentRelay.MaxSocketPathBytes + over - 2);
+        var bytes = Encoding.UTF8.GetByteCount(path);
+        bytes.Should().Be(AgentRelay.MaxSocketPathBytes + over, "the fixture is built in bytes");
+        path.Length.Should().NotBe(bytes, "or this test could not tell the two units apart");
 
         AgentRelay.TooLongForSocket(path).Should().Be(over > 0);
 
         // And the sentence, because a refusal nobody can act on is a crash with better manners.
         var message = AgentRelay.TooLongMessage(path);
-        message.Should().Contain(path.Length.ToString(), "the length they have");
-        message.Should().Contain(AgentRelay.MaxSocketPathBytes.ToString(), "the length they may have");
+        message.Should().Contain(bytes.ToString(), "the SIZE they have, in the unit that is measured");
+        message.Should().NotContain($"{path.Length} bytes", "never the character count labelled as bytes");
+        message.Should().Contain(AgentRelay.MaxSocketPathBytes.ToString(), "the size they may have");
         message.Should().Contain(AgentRelay.SocketOverrideVariable, "and what to set to fix it");
     }
 

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -171,4 +171,25 @@ public class AgentRelayTests
         AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength)).Should().BeFalse();
         AgentRelay.TooLongForSocket(new string('x', AgentRelay.MaxSocketPathLength + 1)).Should().BeTrue();
     }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void TheRefusalNamesThePathTheLengthTheLimitAndTheWayOut(int over)
+    {
+        // The BOUNDARY and the overflow, parameterised — 104 and 105 on macOS, 108 and 109
+        // elsewhere — rather than whatever length a runner's temporary directory happens to give.
+        // Relying on that is how this defect reached a tag: the old test inherited its input from
+        // the environment and so tested the corpse case on Linux and the length cap on macOS,
+        // without saying either.
+        var path = new string('x', AgentRelay.MaxSocketPathLength + over);
+
+        AgentRelay.TooLongForSocket(path).Should().Be(over > 0);
+
+        // And the sentence, because a refusal nobody can act on is a crash with better manners.
+        var message = AgentRelay.TooLongMessage(path);
+        message.Should().Contain(path.Length.ToString(), "the length they have");
+        message.Should().Contain(AgentRelay.MaxSocketPathLength.ToString(), "the length they may have");
+        message.Should().Contain(AgentRelay.SocketOverrideVariable, "and what to set to fix it");
+    }
 }

--- a/src_cli/tests/AgentRelayTests.cs
+++ b/src_cli/tests/AgentRelayTests.cs
@@ -192,4 +192,25 @@ public class AgentRelayTests
         message.Should().Contain(AgentRelay.MaxSocketPathLength.ToString(), "the length they may have");
         message.Should().Contain(AgentRelay.SocketOverrideVariable, "and what to set to fix it");
     }
+
+    [Fact]
+    public async Task APathThatFitsIsNotRefused()
+    {
+        var fits = new string('x', AgentRelay.MaxSocketPathLength);
+
+        (await AgentRelay.RefuseIfTooLongAsync(fits, BrokerContract.Current)).Should().BeNull(
+            "null means carry on — the relay has a path it can bind");
+    }
+
+    [Fact]
+    public async Task APathThatDoesNotFitIsRefusedWithTheUsageCode()
+    {
+        // The exit code matters as much as the sentence: the relay is started from a shell profile,
+        // and a wrong path is the person's mistake to correct rather than a broker that is down.
+        var tooLong = new string('x', AgentRelay.MaxSocketPathLength + 1);
+
+        var refusal = await AgentRelay.RefuseIfTooLongAsync(tooLong, BrokerContract.Current);
+
+        refusal.Should().Be(BrokerContract.Current.Exit("usage"));
+    }
 }


### PR DESCRIPTION
The CLI leg of the 1.7.0 release failed on both macOS runners, so `creds` 0.1.6 did not publish while the extension, the server and the MCP binary did. The cause is a production defect, not a test one.

macOS caps a unix socket path at 104 characters and Linux at 108, and .NET enforces that in `UnixDomainSocketEndPoint`'s constructor with an `ArgumentOutOfRangeException`. That is neither a `SocketException` nor an `IOException`, so it escaped every guard in the relay:

- `IsStaleAsync` let it out of a method whose entire contract is to answer true or false
- `RunAsync`'s bind guard did not name it, so `creds relay` would die with a stack trace instead of its own message
- `TryConnectAsync` — which exists to turn "cannot connect" into a null — let it take the process

It is not a theoretical limit there. macOS's temporary directory alone is about fifty characters, so the test's generated path came to 105. One over the cap.

## What changed

`MaxSocketPathLength` and `TooLongForSocket` state what the platform allows. `IsStaleAsync` answers **false** for a path nothing could ever have bound — its caller deletes what it is told about, and a file must not be unlinked for the crime of living somewhere with a long name. `RunAsync` refuses with the path, its length, the limit and the variable to change. Both catch clauses admit `ArgumentException`.

The test that found this now uses a short name and asserts that it is short, because it is about a corpse and not about the path limit. It was about both by accident, which is why a release discovered the limit instead of a test.

`BrokerClient`'s bridge connect is deliberately left alone: it runs inside `SocketsHttpHandler.ConnectCallback`, which wraps a callback's exception in `HttpRequestException`, and its callers already catch that.

## Test plan

- [x] RED observed in the release log: `ArgumentOutOfRangeException … must be between 1 and 104 characters` from `AgentRelay.cs:101`, on osx-arm64 and osx-x64
- [x] Two new tests: a too-long path is not stale, and the limit is the platform's own
- [x] CLI 85 pass, MCP 40, broker client 81, vault server 769 — 0 failed
- [x] Solution builds with 0 errors

After this merges, `cli-v0.1.6` is re-pushed so the CLI release runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Исправления**
  * Улучшена обработка слишком длинных путей Unix-сокетов с учётом ограничений платформы и длины в UTF-8 байтах.
  * Запуск с недопустимо длинным путём теперь завершается понятным сообщением об ошибке и корректным кодом выхода.
  * Ошибки подключения и привязки к некорректным адресам обрабатываются без аварийного завершения процесса.
  * Проверка устаревших сокетов больше не вызывает исключение для путей, превышающих допустимую длину.
  * Некорректные пути, содержащие не-ASCII символы, теперь обрабатываются корректно.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->